### PR TITLE
On demand ingestion and analysis

### DIFF
--- a/analyzer/main.py
+++ b/analyzer/main.py
@@ -100,11 +100,14 @@ def analyze_all(
         workspaces = await Workspace.find_all().to_list()
 
         for workspace in workspaces:
-            await analyzer.analyze_workspace(
-                workspace,
-                data_start=datetime.now() - timedelta(days=days),
-                data_end=datetime.now(),
-            )
+            try:
+                await analyzer.analyze_workspace(
+                    workspace,
+                    data_start=datetime.now() - timedelta(days=days),
+                    data_end=datetime.now(),
+                )
+            except Exception as e:
+                logger.error(f"Error analyzing workspace {workspace.id}: {str(e)}")
 
         mongo_client.close()
 
@@ -299,12 +302,11 @@ def watch(
                     data_start=task.data_start,
                     data_end=task.data_end,
                 )
-                assert session
                 task.status = Status.completed
                 task.session_id = session.id
-                await task.save()
-
                 logger.info(f"Completed task {task.id}")
+
+                await task.save()
 
             except Exception as e:
                 logger.error(f"Error processing task {task.id}: {str(e)}")

--- a/analyzer/main.py
+++ b/analyzer/main.py
@@ -246,10 +246,9 @@ def repair():
                     workspace
                 )
 
-            typer.echo(f"Updating relevancy counts for session: {session.id}")
             await analyzer.update_relevancy_counts(session)
 
-            if not session.summary:
+            if not session.summary or clusters_without_evaluation:
                 typer.echo(f"Generating summary for session: {session.id}")
                 await analyzer.session_summarizer.generate_summary_for_session(session)
 

--- a/analyzer/main.py
+++ b/analyzer/main.py
@@ -1,6 +1,10 @@
 import asyncio
+from beanie.odm.queries.update import (
+    UpdateResponse,
+)
 import logging
 from datetime import datetime, timedelta
+from beanie.operators import Set
 
 from src.cluster_overview_generator import ClusterOverviewGenerator
 from src.evaluator import ClusterEvaluator
@@ -16,7 +20,7 @@ from src.vector_repository import PineconeVectorRepository
 from langchain.chat_models import init_chat_model
 
 from shared.db import get_client, my_init_beanie
-from shared.models import Cluster, ClusteringSession, Workspace
+from shared.models import AnalysisTask, Cluster, ClusteringSession, Workspace
 
 load_dotenv()
 
@@ -251,6 +255,67 @@ def repair():
         mongo_client.close()
 
     asyncio.run(_repair())
+
+
+@app.command()
+def watch(
+    interval: int = typer.Option(
+        60, "--interval", "-i", help="Check interval in seconds"
+    ),
+):
+    """Watch for pending analysis tasks and execute them."""
+
+    async def _watch():
+        mongo_client, analyzer = await setup()
+
+        logger.info(f"Starting watch loop. Checking every {interval} seconds.")
+
+        while True:
+            task = await AnalysisTask.find_one(
+                AnalysisTask.status == "pending"
+            ).update_one(
+                Set({AnalysisTask.status: "running"}),
+                response_type=UpdateResponse.NEW_DOCUMENT,
+            )
+
+            assert isinstance(task, AnalysisTask) or task is None
+
+            if not task:
+                try:
+                    await asyncio.sleep(interval)
+                except KeyboardInterrupt:
+                    logger.info("Detected keyboard interrupt. Exiting.")
+                    break
+                continue
+
+            logger.info(f"Processing task {task.id} for workspace {task.workspace_id}")
+
+            task.status = "running"  # TODO : find a way to ensure that at this point the task is not already being processed by another worker
+            await task.save()
+
+            workspace = await Workspace.get(task.workspace_id)
+            assert workspace
+
+            try:
+                session = await analyzer.analyze_workspace(
+                    workspace,
+                    data_start=task.data_start,
+                    data_end=task.data_end,
+                )
+                assert session
+                task.status = "completed"
+                task.session_id = session.id
+                await task.save()
+
+                logger.info(f"Completed task {task.id}")
+
+            except Exception as e:
+                logger.error(f"Error processing task {task.id}: {str(e)}")
+                task.status = "failed"
+                task.error = str(e)
+                await task.save()
+
+    asyncio.run(_watch())
 
 
 if __name__ == "__main__":

--- a/analyzer/main.py
+++ b/analyzer/main.py
@@ -262,7 +262,7 @@ def repair():
 @app.command()
 def watch(
     interval: int = typer.Option(
-        60, "--interval", "-i", help="Check interval in seconds"
+        10, "--interval", "-i", help="Check interval in seconds"
     ),
 ):
     """Watch for pending analysis tasks and execute them."""

--- a/analyzer/src/analyzer.py
+++ b/analyzer/src/analyzer.py
@@ -57,7 +57,7 @@ class Analyzer:
         workspace: Workspace,
         data_start: datetime,
         data_end: datetime,
-    ):
+    ) -> ClusteringSession | None:
         session_start = datetime.now()
         assert workspace.id
         logger.info(
@@ -168,6 +168,8 @@ class Analyzer:
 
         session.session_end = datetime.now()
         await session.save()
+
+        return session
 
     async def update_relevancy_counts(self, session: ClusteringSession):
         evaluated_clusters = await Cluster.find(

--- a/analyzer/src/analyzer.py
+++ b/analyzer/src/analyzer.py
@@ -57,7 +57,7 @@ class Analyzer:
         workspace: Workspace,
         data_start: datetime,
         data_end: datetime,
-    ) -> ClusteringSession | None:
+    ) -> ClusteringSession:
         session_start = datetime.now()
         assert workspace.id
         logger.info(
@@ -76,15 +76,10 @@ class Analyzer:
             logger.warn("High number of articles !")
 
         if not all_articles:
-            logger.warn("No articles found. Skipping clustering. No session created.")
-            return
+            raise ValueError("No articles found.")
 
         if len(all_articles) < settings.MIN_ARTICLES_FOR_CLUSTERING:
-            logger.warn(
-                "Not enough articles to cluster. Skipping clustering. No session created."
-            )
-            # TODO : add a warning to the workspace or session
-            return
+            raise ValueError("Not enough articles to cluster.")
 
         vectors = self.vector_repository.fetch_vectors(
             [id_to_str(article.id) for article in all_articles],

--- a/analyzer/src/cluster_overview_generator.py
+++ b/analyzer/src/cluster_overview_generator.py
@@ -118,7 +118,16 @@ class ClusterOverviewGenerator:
                 cluster.overview_generation_error = None
             await cluster.save()
 
-        logger.info(f"Finished generating overviews for {len(clusters)} clusters")
+        exceptions = [
+            overview for overview in overviews if isinstance(overview, Exception)
+        ]
+
+        if exceptions:
+            raise RuntimeError(
+                f"Failed to generate overviews for {len(exceptions)} clusters."
+            )
+
+        logger.info(f"Finished generating overviews for {len(clusters)} clusters.")
 
     async def generate_overviews_for_session(
         self,

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -9,6 +9,7 @@ from shared.db import get_client, my_init_beanie
 
 from src.api_settings import APISettings
 from src.routers import (
+    analysis_tasks,
     clustering,
     ingestion_runs,
     search_query_sets,
@@ -79,6 +80,11 @@ app.include_router(
 app.include_router(
     starters.router,
     prefix="/workspaces/{workspace_id}/starters",
+)
+
+app.include_router(
+    analysis_tasks.router,
+    prefix="/workspaces/{workspace_id}/analysis-tasks",
 )
 
 if __name__ == "__main__":

--- a/backend/src/routers/analysis_tasks.py
+++ b/backend/src/routers/analysis_tasks.py
@@ -1,0 +1,52 @@
+# src/routers/analysis_tasks.py
+from fastapi import APIRouter, HTTPException, status
+from beanie import PydanticObjectId
+from shared.models import AnalysisTask, Status
+from src.dependencies import ExistingWorkspace
+
+from src.schemas import AnalysisTaskCreate
+
+router = APIRouter(tags=["analysis-tasks"])
+
+router.post(
+    "/",
+    response_model=AnalysisTask,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="create_analysis_task",
+)
+
+
+async def create_analysis_task(task: AnalysisTaskCreate, workspace: ExistingWorkspace):
+    assert workspace.id
+    new_task = AnalysisTask(
+        workspace_id=workspace.id,
+        status=Status.pending,
+        data_start=task.data_start,
+        data_end=task.data_end,
+    )
+    await new_task.insert()
+    return new_task
+
+
+@router.get("/", response_model=list[AnalysisTask], operation_id="list_analysis_tasks")
+async def list_analysis_tasks(
+    workspace: ExistingWorkspace,
+    status: Status | None = None,
+):
+    tasks = AnalysisTask.find(AnalysisTask.workspace_id == workspace.id)
+    if status:
+        tasks = tasks.find(AnalysisTask.status == status)
+
+    tasks = await tasks.sort(
+        -AnalysisTask.created_at  # type:ignore
+    ).to_list()
+
+    return tasks
+
+
+@router.get("/{task_id}", response_model=AnalysisTask, operation_id="get_analysis_task")
+async def get_analysis_task(task_id: PydanticObjectId, workspace: ExistingWorkspace):
+    task = await AnalysisTask.get(task_id)
+    if not task or task.workspace_id != workspace.id:
+        raise HTTPException(status_code=404, detail="Analysis task not found")
+    return task

--- a/backend/src/routers/analysis_tasks.py
+++ b/backend/src/routers/analysis_tasks.py
@@ -8,14 +8,13 @@ from src.schemas import AnalysisTaskCreate
 
 router = APIRouter(tags=["analysis-tasks"])
 
-router.post(
+
+@router.post(
     "/",
     response_model=AnalysisTask,
     status_code=status.HTTP_201_CREATED,
     operation_id="create_analysis_task",
 )
-
-
 async def create_analysis_task(task: AnalysisTaskCreate, workspace: ExistingWorkspace):
     assert workspace.id
     new_task = AnalysisTask(

--- a/backend/src/routers/ingestion_runs.py
+++ b/backend/src/routers/ingestion_runs.py
@@ -1,13 +1,50 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from src.dependencies import (
     ExistingIngestionRun,
     ExistingSearchQuerySet,
     ExistingWorkspace,
 )
-from shared.models import IngestionRun
+from shared.models import IngestionRun, SearchQuerySet
 from typing import List
 
+from src.schemas import IngestionRunCreate
+
 router = APIRouter(tags=["ingestion-runs"])
+
+
+@router.post(
+    "/",
+    response_model=IngestionRun,
+    operation_id="create_ingestion_run",
+)
+async def create_ingestion_run(
+    workspace: ExistingWorkspace,
+    run: IngestionRunCreate,
+):
+    assert workspace.id
+
+    query_set = await SearchQuerySet.get(run.search_query_set_id)
+    if not query_set:
+        raise HTTPException(status_code=404, detail="Search query set not found")
+
+    if await IngestionRun.find(
+        IngestionRun.workspace_id == workspace.id,
+        IngestionRun.queries_set_id == query_set.id,
+        IngestionRun.status == "running",
+    ).count():
+        raise HTTPException(
+            status_code=400,
+            detail="Search query set is already being ingested",
+        )
+
+    new_ingestion_run = IngestionRun(
+        workspace_id=workspace.id,
+        queries_set_id=run.search_query_set_id,
+        time_limit=run.time_limit,
+        max_results=run.max_results,
+        status="pending",
+    )
+    return await new_ingestion_run.insert()
 
 
 @router.get("/", response_model=List[IngestionRun], operation_id="list_ingestion_runs")

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from beanie import PydanticObjectId
 from pydantic import BaseModel, HttpUrl
 
 from shared.models import (
@@ -8,6 +9,7 @@ from shared.models import (
     Language,
     ModelDescription,
     ModelTitle,
+    TimeLimit,
 )
 from shared.region import Region
 
@@ -86,3 +88,9 @@ class ClusterWithArticles(BaseModel):
 class AnalysisTaskCreate(BaseModel):
     data_start: datetime
     data_end: datetime
+
+
+class IngestionRunCreate(BaseModel):
+    time_limit: TimeLimit
+    max_results: int
+    search_query_set_id: PydanticObjectId

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -81,3 +81,8 @@ class ClusterWithArticles(BaseModel):
             first_image=cluster.first_image,
             articles=previews,
         )
+
+
+class AnalysisTaskCreate(BaseModel):
+    data_start: datetime
+    data_end: datetime

--- a/frontend/pages/4_🔍Topics.py
+++ b/frontend/pages/4_🔍Topics.py
@@ -50,7 +50,7 @@ with st.sidebar:
         end_date = datetime.combine(end_date, datetime.max.time())
 
         submit_button = st.form_submit_button(
-            "Create Analysis Task", use_container_width=True
+            "Start analysis", use_container_width=True
         )
 
         if submit_button:

--- a/frontend/sdk/so_insights_client/api/analysis_tasks/create_analysis_task.py
+++ b/frontend/sdk/so_insights_client/api/analysis_tasks/create_analysis_task.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.analysis_task import AnalysisTask
+from ...models.analysis_task_create import AnalysisTaskCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    workspace_id: str,
+    *,
+    body: AnalysisTaskCreate,
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": f"/workspaces/{workspace_id}/analysis-tasks/",
+    }
+
+    _body = body.to_dict()
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = AnalysisTask.from_dict(response.json())
+
+        return response_201
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AnalysisTaskCreate,
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    """Create Analysis Task
+
+    Args:
+        workspace_id (str):
+        body (AnalysisTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[AnalysisTask, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AnalysisTaskCreate,
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    """Create Analysis Task
+
+    Args:
+        workspace_id (str):
+        body (AnalysisTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[AnalysisTask, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        workspace_id=workspace_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AnalysisTaskCreate,
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    """Create Analysis Task
+
+    Args:
+        workspace_id (str):
+        body (AnalysisTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[AnalysisTask, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AnalysisTaskCreate,
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    """Create Analysis Task
+
+    Args:
+        workspace_id (str):
+        body (AnalysisTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[AnalysisTask, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            workspace_id=workspace_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/api/analysis_tasks/get_analysis_task.py
+++ b/frontend/sdk/so_insights_client/api/analysis_tasks/get_analysis_task.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.analysis_task import AnalysisTask
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    workspace_id: str,
+    task_id: str,
+) -> Dict[str, Any]:
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": f"/workspaces/{workspace_id}/analysis-tasks/{task_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = AnalysisTask.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workspace_id: str,
+    task_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    """Get Analysis Task
+
+    Args:
+        workspace_id (str):
+        task_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[AnalysisTask, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        task_id=task_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workspace_id: str,
+    task_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    """Get Analysis Task
+
+    Args:
+        workspace_id (str):
+        task_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[AnalysisTask, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        workspace_id=workspace_id,
+        task_id=task_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workspace_id: str,
+    task_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[AnalysisTask, HTTPValidationError]]:
+    """Get Analysis Task
+
+    Args:
+        workspace_id (str):
+        task_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[AnalysisTask, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        task_id=task_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workspace_id: str,
+    task_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[AnalysisTask, HTTPValidationError]]:
+    """Get Analysis Task
+
+    Args:
+        workspace_id (str):
+        task_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[AnalysisTask, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            workspace_id=workspace_id,
+            task_id=task_id,
+            client=client,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/api/analysis_tasks/list_analysis_tasks.py
+++ b/frontend/sdk/so_insights_client/api/analysis_tasks/list_analysis_tasks.py
@@ -1,0 +1,189 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.analysis_task import AnalysisTask
+from ...models.http_validation_error import HTTPValidationError
+from ...models.status import Status
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    workspace_id: str,
+    *,
+    status: Union[None, Status, Unset] = UNSET,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+
+    json_status: Union[None, Unset, str]
+    if isinstance(status, Unset):
+        json_status = UNSET
+    elif isinstance(status, Status):
+        json_status = status.value
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": f"/workspaces/{workspace_id}/analysis-tasks/",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = AnalysisTask.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[None, Status, Unset] = UNSET,
+) -> Response[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    """List Analysis Tasks
+
+    Args:
+        workspace_id (str):
+        status (Union[None, Status, Unset]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, List['AnalysisTask']]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        status=status,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[None, Status, Unset] = UNSET,
+) -> Optional[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    """List Analysis Tasks
+
+    Args:
+        workspace_id (str):
+        status (Union[None, Status, Unset]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, List['AnalysisTask']]
+    """
+
+    return sync_detailed(
+        workspace_id=workspace_id,
+        client=client,
+        status=status,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[None, Status, Unset] = UNSET,
+) -> Response[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    """List Analysis Tasks
+
+    Args:
+        workspace_id (str):
+        status (Union[None, Status, Unset]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, List['AnalysisTask']]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        status=status,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[None, Status, Unset] = UNSET,
+) -> Optional[Union[HTTPValidationError, List["AnalysisTask"]]]:
+    """List Analysis Tasks
+
+    Args:
+        workspace_id (str):
+        status (Union[None, Status, Unset]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, List['AnalysisTask']]
+    """
+
+    return (
+        await asyncio_detailed(
+            workspace_id=workspace_id,
+            client=client,
+            status=status,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_runs/create_ingestion_run.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_runs/create_ingestion_run.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.ingestion_run import IngestionRun
+from ...models.ingestion_run_create import IngestionRunCreate
+from ...types import Response
+
+
+def _get_kwargs(
+    workspace_id: str,
+    *,
+    body: IngestionRunCreate,
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": f"/workspaces/{workspace_id}/ingestion-runs/",
+    }
+
+    _body = body.to_dict()
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, IngestionRun]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = IngestionRun.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, IngestionRun]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IngestionRunCreate,
+) -> Response[Union[HTTPValidationError, IngestionRun]]:
+    """Create Ingestion Run
+
+    Args:
+        workspace_id (str):
+        body (IngestionRunCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, IngestionRun]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IngestionRunCreate,
+) -> Optional[Union[HTTPValidationError, IngestionRun]]:
+    """Create Ingestion Run
+
+    Args:
+        workspace_id (str):
+        body (IngestionRunCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, IngestionRun]
+    """
+
+    return sync_detailed(
+        workspace_id=workspace_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IngestionRunCreate,
+) -> Response[Union[HTTPValidationError, IngestionRun]]:
+    """Create Ingestion Run
+
+    Args:
+        workspace_id (str):
+        body (IngestionRunCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, IngestionRun]]
+    """
+
+    kwargs = _get_kwargs(
+        workspace_id=workspace_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workspace_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IngestionRunCreate,
+) -> Optional[Union[HTTPValidationError, IngestionRun]]:
+    """Create Ingestion Run
+
+    Args:
+        workspace_id (str):
+        body (IngestionRunCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, IngestionRun]
+    """
+
+    return (
+        await asyncio_detailed(
+            workspace_id=workspace_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/models/__init__.py
+++ b/frontend/sdk/so_insights_client/models/__init__.py
@@ -1,5 +1,7 @@
 """Contains all the data models used in inputs/outputs"""
 
+from .analysis_task import AnalysisTask
+from .analysis_task_create import AnalysisTaskCreate
 from .article_preview import ArticlePreview
 from .cluster import Cluster
 from .cluster_evaluation import ClusterEvaluation
@@ -20,6 +22,7 @@ from .relevancy_filter import RelevancyFilter
 from .search_query_set import SearchQuerySet
 from .search_query_set_create import SearchQuerySetCreate
 from .search_query_set_update import SearchQuerySetUpdate
+from .status import Status
 from .time_limit import TimeLimit
 from .validation_error import ValidationError
 from .workspace import Workspace
@@ -27,6 +30,8 @@ from .workspace_create import WorkspaceCreate
 from .workspace_update import WorkspaceUpdate
 
 __all__ = (
+    "AnalysisTask",
+    "AnalysisTaskCreate",
     "ArticlePreview",
     "Cluster",
     "ClusterEvaluation",
@@ -47,6 +52,7 @@ __all__ = (
     "SearchQuerySet",
     "SearchQuerySetCreate",
     "SearchQuerySetUpdate",
+    "Status",
     "TimeLimit",
     "ValidationError",
     "Workspace",

--- a/frontend/sdk/so_insights_client/models/__init__.py
+++ b/frontend/sdk/so_insights_client/models/__init__.py
@@ -14,6 +14,7 @@ from .clustering_session_metadata import ClusteringSessionMetadata
 from .hdbscan_settings import HdbscanSettings
 from .http_validation_error import HTTPValidationError
 from .ingestion_run import IngestionRun
+from .ingestion_run_create import IngestionRunCreate
 from .ingestion_run_status import IngestionRunStatus
 from .language import Language
 from .list_clusters_for_session_relevance_levels_type_0_item import ListClustersForSessionRelevanceLevelsType0Item
@@ -44,6 +45,7 @@ __all__ = (
     "HdbscanSettings",
     "HTTPValidationError",
     "IngestionRun",
+    "IngestionRunCreate",
     "IngestionRunStatus",
     "Language",
     "ListClustersForSessionRelevanceLevelsType0Item",

--- a/frontend/sdk/so_insights_client/models/analysis_task.py
+++ b/frontend/sdk/so_insights_client/models/analysis_task.py
@@ -1,0 +1,171 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.status import Status
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AnalysisTask")
+
+
+@_attrs_define
+class AnalysisTask:
+    """
+    Attributes:
+        workspace_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+        data_start (datetime.datetime):
+        data_end (datetime.datetime):
+        field_id (Union[None, Unset, str]): MongoDB document ObjectID
+        created_at (Union[Unset, datetime.datetime]):
+        status (Union[Unset, Status]):  Default: Status.PENDING.
+        error (Union[None, Unset, str]):
+        session_id (Union[None, Unset, str]):
+    """
+
+    workspace_id: str
+    data_start: datetime.datetime
+    data_end: datetime.datetime
+    field_id: Union[None, Unset, str] = UNSET
+    created_at: Union[Unset, datetime.datetime] = UNSET
+    status: Union[Unset, Status] = Status.PENDING
+    error: Union[None, Unset, str] = UNSET
+    session_id: Union[None, Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        workspace_id = self.workspace_id
+
+        data_start = self.data_start.isoformat()
+
+        data_end = self.data_end.isoformat()
+
+        field_id: Union[None, Unset, str]
+        if isinstance(self.field_id, Unset):
+            field_id = UNSET
+        else:
+            field_id = self.field_id
+
+        created_at: Union[Unset, str] = UNSET
+        if not isinstance(self.created_at, Unset):
+            created_at = self.created_at.isoformat()
+
+        status: Union[Unset, str] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status.value
+
+        error: Union[None, Unset, str]
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
+
+        session_id: Union[None, Unset, str]
+        if isinstance(self.session_id, Unset):
+            session_id = UNSET
+        else:
+            session_id = self.session_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "workspace_id": workspace_id,
+                "data_start": data_start,
+                "data_end": data_end,
+            }
+        )
+        if field_id is not UNSET:
+            field_dict["_id"] = field_id
+        if created_at is not UNSET:
+            field_dict["created_at"] = created_at
+        if status is not UNSET:
+            field_dict["status"] = status
+        if error is not UNSET:
+            field_dict["error"] = error
+        if session_id is not UNSET:
+            field_dict["session_id"] = session_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        workspace_id = d.pop("workspace_id")
+
+        data_start = isoparse(d.pop("data_start"))
+
+        data_end = isoparse(d.pop("data_end"))
+
+        def _parse_field_id(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        field_id = _parse_field_id(d.pop("_id", UNSET))
+
+        _created_at = d.pop("created_at", UNSET)
+        created_at: Union[Unset, datetime.datetime]
+        if isinstance(_created_at, Unset):
+            created_at = UNSET
+        else:
+            created_at = isoparse(_created_at)
+
+        _status = d.pop("status", UNSET)
+        status: Union[Unset, Status]
+        if isinstance(_status, Unset):
+            status = UNSET
+        else:
+            status = Status(_status)
+
+        def _parse_error(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
+        def _parse_session_id(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        session_id = _parse_session_id(d.pop("session_id", UNSET))
+
+        analysis_task = cls(
+            workspace_id=workspace_id,
+            data_start=data_start,
+            data_end=data_end,
+            field_id=field_id,
+            created_at=created_at,
+            status=status,
+            error=error,
+            session_id=session_id,
+        )
+
+        analysis_task.additional_properties = d
+        return analysis_task
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/frontend/sdk/so_insights_client/models/analysis_task_create.py
+++ b/frontend/sdk/so_insights_client/models/analysis_task_create.py
@@ -1,0 +1,68 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="AnalysisTaskCreate")
+
+
+@_attrs_define
+class AnalysisTaskCreate:
+    """
+    Attributes:
+        data_start (datetime.datetime):
+        data_end (datetime.datetime):
+    """
+
+    data_start: datetime.datetime
+    data_end: datetime.datetime
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data_start = self.data_start.isoformat()
+
+        data_end = self.data_end.isoformat()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data_start": data_start,
+                "data_end": data_end,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        data_start = isoparse(d.pop("data_start"))
+
+        data_end = isoparse(d.pop("data_end"))
+
+        analysis_task_create = cls(
+            data_start=data_start,
+            data_end=data_end,
+        )
+
+        analysis_task_create.additional_properties = d
+        return analysis_task_create
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/frontend/sdk/so_insights_client/models/ingestion_run_create.py
+++ b/frontend/sdk/so_insights_client/models/ingestion_run_create.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.time_limit import TimeLimit
+
+T = TypeVar("T", bound="IngestionRunCreate")
+
+
+@_attrs_define
+class IngestionRunCreate:
+    """
+    Attributes:
+        time_limit (TimeLimit):
+        max_results (int):
+        search_query_set_id (str):  Example: 5eb7cf5a86d9755df3a6c593.
+    """
+
+    time_limit: TimeLimit
+    max_results: int
+    search_query_set_id: str
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        time_limit = self.time_limit.value
+
+        max_results = self.max_results
+
+        search_query_set_id = self.search_query_set_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "time_limit": time_limit,
+                "max_results": max_results,
+                "search_query_set_id": search_query_set_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        time_limit = TimeLimit(d.pop("time_limit"))
+
+        max_results = d.pop("max_results")
+
+        search_query_set_id = d.pop("search_query_set_id")
+
+        ingestion_run_create = cls(
+            time_limit=time_limit,
+            max_results=max_results,
+            search_query_set_id=search_query_set_id,
+        )
+
+        ingestion_run_create.additional_properties = d
+        return ingestion_run_create
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/frontend/sdk/so_insights_client/models/status.py
+++ b/frontend/sdk/so_insights_client/models/status.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class IngestionRunStatus(str, Enum):
+class Status(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     PENDING = "pending"

--- a/ingester/main.py
+++ b/ingester/main.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from itertools import batched
+from typing import Optional
 
 import typer
 from beanie import BulkWriter, PydanticObjectId, UpdateResponse
@@ -338,7 +339,7 @@ def create_ingestion_task(
 
 @app.command()
 def create_ingestion_tasks(
-    workspace_id: str | None = typer.Option(
+    workspace_id: Optional[str] = typer.Option(
         None,
         "-w",
         "--workspace-id",

--- a/shared/shared/db.py
+++ b/shared/shared/db.py
@@ -1,6 +1,7 @@
 from beanie import init_beanie
 from shared.db_settings import DBSettings
 from shared.models import (
+    AnalysisTask,
     Cluster,
     Workspace,
     SearchQuerySet,
@@ -30,6 +31,7 @@ async def my_init_beanie(client):
             ClusteringSession,
             Article,
             Starters,
+            AnalysisTask,
         ],
     )
 

--- a/shared/shared/db_settings.py
+++ b/shared/shared/db_settings.py
@@ -17,3 +17,4 @@ class DBSettings(BaseSettings):
     mongodb_clusters_collection: str = "clusters"
     mongodb_clustering_sessions_collection: str = "clustering_sessions"
     mongodb_starters_collection: str = "starters"
+    mongodb_analysis_tasks_collection: str = "analysis_tasks"

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -84,7 +84,7 @@ class IngestionRun(Document):
     max_results: int = Field(..., ge=1, le=100)
     created_at: PastDatetime = Field(default_factory=utc_datetime_factory)
     end_at: PastDatetime | None = None
-    status: Literal["running", "completed", "failed"]
+    status: Literal["pending", "running", "completed", "failed"]
     successfull_queries: int | None = None
     error: str | None = (
         None  # can be timeout (we should check for long duration ingestion and mark it as failed)
@@ -156,6 +156,17 @@ class Article(Document):
 
 
 RelevanceLevel = Literal["highly_relevant", "somewhat_relevant", "not_relevant"]
+
+
+class AnalysisTask(Document):
+    workspace_id: Annotated[PydanticObjectId, Indexed()]
+    created_at: PastDatetime = Field(default_factory=utc_datetime_factory)
+    status: Literal["pending", "running", "completed", "failed"]
+    error: str | None = None
+    session_id: PydanticObjectId | None = None
+
+    class Settings:
+        name = DBSettings().mongodb_analysis_tasks_collection
 
 
 class ClusteringSession(Document):

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -165,16 +165,19 @@ class AnalysisTask(Document):
     error: str | None = None
     session_id: PydanticObjectId | None = None
 
+    data_start: PastDatetime
+    data_end: datetime
+
     class Settings:
         name = DBSettings().mongodb_analysis_tasks_collection
 
 
 class ClusteringSession(Document):
     workspace_id: Annotated[PydanticObjectId, Indexed()]
-    session_start: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    session_end: datetime | None = None
+    session_start: PastDatetime = Field(default_factory=utc_datetime_factory)
+    session_end: PastDatetime | None = None
 
-    data_start: datetime
+    data_start: PastDatetime
     data_end: datetime
     nb_days: int
 

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from enum import Enum
 from beanie.odm.queries.find import FindMany
 from typing import Annotated, Any, Dict, Literal
 
@@ -158,10 +159,17 @@ class Article(Document):
 RelevanceLevel = Literal["highly_relevant", "somewhat_relevant", "not_relevant"]
 
 
+class Status(str, Enum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+
+
 class AnalysisTask(Document):
     workspace_id: Annotated[PydanticObjectId, Indexed()]
     created_at: PastDatetime = Field(default_factory=utc_datetime_factory)
-    status: Literal["pending", "running", "completed", "failed"]
+    status: Status = Status.pending
     error: str | None = None
     session_id: PydanticObjectId | None = None
 


### PR DESCRIPTION
## Problem
Our current system lacks flexibility in data ingestion and analysis, with users having to wait for scheduled tasks and being unable to trigger custom analyses.

## Solution
This PR implements on-demand ingestion and analysis capabilities, allowing users to trigger these processes as needed and specify custom parameters.

## Changes

### Analyzer
- Added `AnalysisTask` model for pending analysis tasks
- Implemented "watch" command to process pending tasks
- Added API routes for creating and retrieving analysis tasks
- Updated frontend to allow users to request new analyses

### Ingester
- Modified `IngestionRun` model to include "pending" status
- Implemented "watch" command to process pending ingestion runs
- Added API routes for creating ingestion runs
- Updated frontend to allow triggering ingestion runs for specific search query sets

### API
- New endpoints for creating analysis tasks and ingestion runs
- Updated existing endpoints to support new functionality

### Frontend
- New form in Topics detection page sidebar for creating analysis tasks
- New button in Article Scraping page for creating ingestion runs

## Implementation Details
- Both analyzer and ingester now have background workers ("watch" commands) that process pending tasks
- Used atomic operations to ensure task uniqueness in distributed environments

Please review and let me know if any changes or additional information is needed.