### PR TITLE
Feature/organizations auth secret code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ The Analyzer component handles:
 ### Backend
 
 The Backend provides:
-- RESTful API endpoints for data access and management on the frontend
+- RESTful API endpoints for authentication and data access and management on the frontend
 
 ### Frontend
 
 The Frontend offers a Streamlit interface for:
 
+- Logging in an organization
 - Managing workspaces and search queries
 - Configuring data sources (web search and RSS feeds)
 - Manually triggering ingestion and analysis tasks

--- a/backend/README.md
+++ b/backend/README.md
@@ -55,3 +55,19 @@ For development purposes, you might want to run the application outside of Docke
 4. Install dependencies: `poetry install`
 5. Set up your environment variables in a `.env` file in the `backend` directory.
 6. Run the application: `poetry run uvicorn src.api:app --reload`
+
+# Authentication
+
+The SO Insights backend requires organization-level authentication for accessing most of its resources. This is done using the X-Organization-ID header in the request.
+
+### Authentication Flow
+SoInsights Administrators create Organizations and their access codes for the clients.
+Users receive the code and use it to login on the platform. 
+Internally, the code is exchanged against the organization ID, which is subsequently sent in each request as `X-Organization-ID` header.
+We wrongly assume that the org ID can't be guessed, and dangerously use it for authentication.
+
+### Important Notes
+
+This authentication mechanism is not highly secure and is designed for demonstration purposes. Ensure that access codes are kept private.
+
+Future updates may introduce more robust authentication mechanisms

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -3,11 +3,12 @@ import sys
 from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
 from shared.db import get_client, my_init_beanie
 
 from src.api_settings import api_settings
+from src.dependencies import get_organization
 from src.routers import (
     clustering,
     ingestion_configs,
@@ -61,24 +62,32 @@ async def root():
 
 
 app.include_router(organizations.router, prefix="/organizations")
-app.include_router(workspaces.router, prefix="/workspaces")
+app.include_router(
+    workspaces.router,
+    prefix="/workspaces",
+    dependencies=[Depends(get_organization)],
+)
 app.include_router(
     ingestion_configs.router,
     prefix="/workspaces/{workspace_id}/ingestion-configs",
+    dependencies=[Depends(get_organization)],
 )
 app.include_router(
     ingestion_runs.router,
     prefix="/workspaces/{workspace_id}/ingestion-runs",
+    dependencies=[Depends(get_organization)],
 )
 
 app.include_router(
     clustering.router,
     prefix="/workspaces/{workspace_id}/clustering",
+    dependencies=[Depends(get_organization)],
 )
 
 app.include_router(
     starters.router,
     prefix="/workspaces/{workspace_id}/starters",
+    dependencies=[Depends(get_organization)],
 )
 
 

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -12,6 +12,7 @@ from src.routers import (
     clustering,
     ingestion_configs,
     ingestion_runs,
+    organizations,
     starters,
     workspaces,
 )
@@ -59,6 +60,7 @@ async def root():
     return {"message": "Welcome to so_insights API"}
 
 
+app.include_router(organizations.router, prefix="/organizations")
 app.include_router(workspaces.router, prefix="/workspaces")
 app.include_router(
     ingestion_configs.router,
@@ -78,6 +80,7 @@ app.include_router(
     starters.router,
     prefix="/workspaces/{workspace_id}/starters",
 )
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -8,10 +8,22 @@ from shared.models import (
     ClusteringSession,
     IngestionConfig,
     IngestionRun,
+    Organization,
     RssIngestionConfig,
     SearchIngestionConfig,
     Workspace,
 )
+
+
+async def get_organization(organization_id: str | PydanticObjectId) -> Organization:
+    organization = await Organization.get(organization_id)
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    assert organization.id
+    return organization
+
+
+ExistingOrganization = Annotated[Organization, Depends(get_organization)]
 
 
 async def get_workspace(workspace_id: str | PydanticObjectId) -> Workspace:

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from beanie import PydanticObjectId
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Header
 
 from shared.models import (
     Cluster,
@@ -15,10 +15,10 @@ from shared.models import (
 )
 
 
-async def get_organization(organization_id: str | PydanticObjectId) -> Organization:
-    organization = await Organization.get(organization_id)
+async def get_organization(x_organization_id: Annotated[str, Header()]) -> Organization:
+    organization = await Organization.get(x_organization_id)
     if not organization:
-        raise HTTPException(status_code=404, detail="Organization not found")
+        raise HTTPException(status_code=400, detail="Invalid X-Organization-ID header")
     assert organization.id
     return organization
 
@@ -26,10 +26,13 @@ async def get_organization(organization_id: str | PydanticObjectId) -> Organizat
 ExistingOrganization = Annotated[Organization, Depends(get_organization)]
 
 
-async def get_workspace(workspace_id: str | PydanticObjectId) -> Workspace:
+async def get_workspace(
+    organization: ExistingOrganization, workspace_id: str | PydanticObjectId
+) -> Workspace:
     workspace = await Workspace.get(workspace_id)
-    if not workspace:
+    if not workspace or workspace.organization_id != organization.id:
         raise HTTPException(status_code=404, detail="Workspace not found")
+
     assert workspace.id
     return workspace
 

--- a/backend/src/routers/organizations.py
+++ b/backend/src/routers/organizations.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, HTTPException, Query, status
-from mongomock import DuplicateKeyError
 from pydantic import SecretStr
+from pymongo.errors import DuplicateKeyError
+
 from shared.models import Organization
 from src.dependencies import ExistingOrganization
 from src.schemas import OrganizationCreate
-
 
 router = APIRouter(tags=["organizations"])
 

--- a/backend/src/routers/organizations.py
+++ b/backend/src/routers/organizations.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, HTTPException, Query, status
+from mongomock import DuplicateKeyError
+from pydantic import SecretStr
+from shared.models import Organization
+from src.dependencies import ExistingOrganization
+from src.schemas import OrganizationCreate
+
+
+router = APIRouter(tags=["organizations"])
+
+
+# Disabled because only admins should be able to access this, and we don't have
+# roles implemented yet.
+# @router.post(
+#     "/",
+#     response_model=Organization,
+#     status_code=status.HTTP_201_CREATED,
+#     operation_id="create_organization",
+# )
+# async def create_organization(body: OrganizationCreate):
+#     """
+#     Create a new organization.
+
+#     - Fails with 409 if 'name' or 'secret_code' is already in use
+#     """
+#     new_org = Organization(
+#         name=body.name.strip(),
+#         secret_code=SecretStr(body.secret_code.strip()),
+#     )
+
+#     try:
+#         return await new_org.insert()
+#     except DuplicateKeyError:
+#         raise HTTPException(
+#             status_code=status.HTTP_409_CONFLICT,
+#             detail="Organization name or secret_code already in use.",
+#         )
+
+
+# Disabled because only admins should be able to access this, and we don't have
+# roles implemented yet.
+# @router.get(
+#     "/",
+#     response_model=list[Organization],
+#     operation_id="list_organizations",
+# )
+# async def list_organizations():
+#     """
+#     List all organizations.
+#     (Admins only in real scenario, but minimal for now)
+#     """
+#     return (
+#         await Organization.find_all()
+#         .sort(
+#             -Organization.created_at,  # type: ignore
+#         )
+#         .to_list()
+#     )
+
+
+@router.get(
+    "/by-secret-code",
+    response_model=Organization,
+    operation_id="get_organization_by_secret_code",
+)
+async def get_organization_by_secret_code(
+    code: str = Query(..., description="Organization secret code"),
+):
+    """
+    Retrieve an organization by its secret code.
+    Returns 404 if none found.
+    """
+    org = await Organization.find_one(Organization.secret_code == code)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    return org
+
+
+@router.get(
+    "/{organization_id}",
+    response_model=Organization,
+    operation_id="get_organization",
+)
+async def get_organization(organization: ExistingOrganization):
+    """
+    Retrieve a single organization by ID.
+    """
+    return organization

--- a/backend/src/routers/workspaces.py
+++ b/backend/src/routers/workspaces.py
@@ -33,7 +33,9 @@ async def list_workspaces(
         else Workspace.find_all()
     )
 
-    return await workspaces.sort(Workspace.created_at).to_list()
+    return await workspaces.sort(
+        Workspace.created_at,  # type: ignore
+    ).to_list()
 
 
 @router.get(

--- a/backend/src/routers/workspaces.py
+++ b/backend/src/routers/workspaces.py
@@ -32,12 +32,12 @@ async def create_workspace(
     operation_id="list_workspaces",
 )
 async def list_workspaces(
+    organization: ExistingOrganization,
     enabled: bool | None = None,
 ):
-    workspaces = (
-        Workspace.find(Workspace.enabled == enabled)
-        if enabled is not None
-        else Workspace.find_all()
+    workspaces = Workspace.find(
+        Workspace.organization_id == organization.id,
+        *[Workspace.enabled == enabled] if enabled is not None else [],
     )
 
     return await workspaces.sort(

--- a/backend/src/routers/workspaces.py
+++ b/backend/src/routers/workspaces.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, status
-from src.dependencies import ExistingWorkspace
+from src.dependencies import ExistingWorkspace, ExistingOrganization
 from shared.models import Workspace, utc_datetime_factory
 from src.schemas import WorkspaceUpdate, WorkspaceCreate
 from logging import getLogger
@@ -15,8 +15,15 @@ router = APIRouter(tags=["workspaces"])
     status_code=status.HTTP_201_CREATED,
     operation_id="create_workspace",
 )
-async def create_workspace(workspace: WorkspaceCreate):
-    return await Workspace(**workspace.model_dump()).insert()
+async def create_workspace(
+    organization: ExistingOrganization, workspace: WorkspaceCreate
+):
+    assert organization.id
+
+    return await Workspace(
+        organization_id=organization.id,
+        **workspace.model_dump(),
+    ).insert()
 
 
 @router.get(

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -1,6 +1,14 @@
 from datetime import datetime
+from typing import Annotated
 from beanie import PydanticObjectId
-from pydantic import BaseModel, Field, HttpUrl, PastDatetime
+from pydantic import (
+    BaseModel,
+    Field,
+    HttpUrl,
+    PastDatetime,
+    SecretStr,
+    StringConstraints,
+)
 
 from shared.models import (
     Cluster,
@@ -14,7 +22,27 @@ from shared.models import (
 from shared.region import Region
 
 
+class OrganizationCreate(BaseModel):
+    name: ModelTitle = Field(..., description="Unique name of the organization")
+
+    secret_code: Annotated[
+        str,
+        StringConstraints(
+            min_length=8,
+            max_length=64,
+            strip_whitespace=True,
+        ),
+    ] = Field(
+        ...,
+        description="Secret code for organization access. Will be stored in plain text.",
+    )
+
+    class Config:
+        extra = "forbid"
+
+
 class WorkspaceCreate(BaseModel):
+    organization_id: PydanticObjectId
     name: ModelTitle
     description: ModelDescription = ""
     language: Language

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -42,7 +42,6 @@ class OrganizationCreate(BaseModel):
 
 
 class WorkspaceCreate(BaseModel):
-    organization_id: PydanticObjectId
     name: ModelTitle
     description: ModelDescription = ""
     language: Language

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -105,3 +105,21 @@ To run the docker image, run :
 docker run -p 8501:8501  -e STREAMLIT_SERVER_PORT=8501 -e STREAMLIT_SERVER_ADDRESS=localhost  -e SO_INSIGHTS_API_URL="<api_url>" --env-file .\frontend\.env     -t so-insights-frontend
 ```
 
+
+# Authentication
+
+The frontend application requires authentication to interact with the backend API. This is achieved using the organization's `X-Organization-ID` header.
+
+### Login Flow
+
+1. **Access Code Input:**
+   - When accessing the application for the first time, users are prompted to enter a secret access code provided by the administrator.
+
+2. **Exchange for Organization ID:**
+   - The access code is sent to the backend API endpoint `/organizations/by-secret-code` to retrieve the corresponding `organization_id`.
+
+3. **Session Persistence:**
+   - The `organization_id` is stored in the user's session and used to authenticate subsequent API calls.
+
+4. **Headers in API Requests:**
+   - All API requests made by the frontend include the `X-Organization-ID` header to authenticate the user.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -11,42 +11,64 @@ from streamlit_theme import st_theme
 
 
 def check_organization_secret():
-    if not st.session_state.get("organization"):
-        with st.form("organization_secret_form"):
-            code = st.text_input(
-                "Secret Code",
-                type="password",
-                help="Enter the secret code you received",
-                key="organization_secret_code",
-            )
-            login_button = st.form_submit_button("Login")
+    """
+    Validates and logs the user into an organization using a secret code.
 
-        if not login_button:
-            st.stop()
+    If the secret code corresponds to a valid organization, we keep the organization_id
+    in session state that will allow us to create an authenticated client.
 
-        if not code.strip():
-            st.error("Please enter a valid secret code")
-            st.stop()
+    Note that nothing of this is secure. This is only for demo purposes.
+    """
+    if "organization" in st.session_state:
+        # Already logged in
+        return
 
-        org = get_organization_by_secret_code.sync(
-            client=get_client(),
-            code=code,
+    st.header("Welcome to SoInsights")
+
+    # Display login form
+    with st.form("organization_secret_form"):
+        # Display an information box with guidance
+        st.info(
+            "Enter the access code provided to you. "
+            "If you don’t have one, please contact your administrator for assistance.",
+            icon="ℹ️",
         )
 
-        if not org or isinstance(org, HTTPValidationError):
-            st.error("Invalid secret code")
-            st.stop()
-
-        assert isinstance(org, Organization)
-
-        st.session_state.organization = org
-        st.session_state.organization_id = org.field_id
-
-        create_toast(
-            f"Successfully logged in `{org.name}` organization",
+        code = st.text_input(
+            "🔒 Access Code",
+            type="password",
+            key="organization_secret_code",
+        )
+        login_button = st.form_submit_button(
+            "Login", use_container_width=True, type="primary"
         )
 
-        st.rerun()
+    if not login_button:
+        st.stop()
+
+    if not code.strip():
+        st.error("Please enter a valid secret code")
+        st.stop()
+
+    org = get_organization_by_secret_code.sync(
+        client=get_client(),
+        code=code,
+    )
+
+    if not org or isinstance(org, HTTPValidationError):
+        st.error("Could not log in. Please check the secret code and try again.")
+        st.stop()
+
+    assert isinstance(org, Organization)
+
+    create_toast(
+        f"Successfully logged in `{org.name}` organization",
+    )
+
+    st.session_state.organization = org
+    st.session_state.organization_id = org.field_id
+
+    st.rerun()
 
 
 def _select_workspace(client, on_change) -> None:
@@ -114,6 +136,8 @@ def _select_workspace(client, on_change) -> None:
 if __name__ == "__main__":
     load_dotenv()
 
+    check_organization_secret()
+
     st.set_page_config(layout="wide")
 
     theme = st_theme()
@@ -122,8 +146,6 @@ if __name__ == "__main__":
             st.logo(app_settings.LOGO_LIGHT_URL)
         elif base == "dark" and app_settings.LOGO_DARK_URL:
             st.logo(app_settings.LOGO_DARK_URL)
-
-    check_organization_secret()
 
     client = get_authenticated_client(st.session_state.organization_id)
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -5,12 +5,12 @@ from sdk.so_insights_client.api.workspaces import list_workspaces
 from sdk.so_insights_client.api.organizations import get_organization_by_secret_code
 from sdk.so_insights_client.models.workspace import Workspace
 from src.app_settings import app_settings
-from src.shared import create_toast, get_client
+from src.shared import create_toast, get_authenticated_client, get_client
 import streamlit as st
 from streamlit_theme import st_theme
 
 
-def check_organization_secret(client):
+def check_organization_secret():
     if not st.session_state.get("organization"):
         with st.form("organization_secret_form"):
             code = st.text_input(
@@ -39,13 +39,11 @@ def check_organization_secret(client):
 
         assert isinstance(org, Organization)
 
-        st.session_state.organization = {
-            "name": org.name,
-            "id": org.field_id,
-        }
+        st.session_state.organization = org
+        st.session_state.organization_id = org.field_id
 
         create_toast(
-            f"Successfully logged in `{st.session_state.organization['name']}` organization",
+            f"Successfully logged in `{org.name}` organization",
         )
 
         st.rerun()
@@ -125,9 +123,9 @@ if __name__ == "__main__":
         elif base == "dark" and app_settings.LOGO_DARK_URL:
             st.logo(app_settings.LOGO_DARK_URL)
 
-    client = get_client()
+    check_organization_secret()
 
-    check_organization_secret(client=client)
+    client = get_authenticated_client(st.session_state.organization_id)
 
     pg = st.navigation(
         [

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,9 +2,43 @@ from dotenv import load_dotenv
 from sdk.so_insights_client.api.workspaces import list_workspaces
 from sdk.so_insights_client.models.workspace import Workspace
 from src.app_settings import app_settings
-from src.shared import get_client
+from src.shared import create_toast, get_client
 import streamlit as st
 from streamlit_theme import st_theme
+
+
+def check_organization_secret():
+    if not st.session_state.get("organization"):
+        with st.form("organization_secret_form"):
+            code = st.text_input(
+                "Secret Code",
+                type="password",
+                help="Enter the secret code you received",
+                key="organization_secret_code",
+            )
+            login_button = st.form_submit_button("Login")
+
+        if not login_button:
+            st.stop()
+
+        if not code.strip():
+            st.error("Please enter a valid secret code")
+            st.stop()
+
+        if code != "test":
+            st.error("Invalid secret code")
+            st.stop()
+
+        st.session_state.organization = {
+            "name": "default",
+            "id": "67771ad64343ae2b3000d53b",
+        }
+
+        create_toast(
+            f"Successfully logged in `{st.session_state.organization['name']}` organization",
+        )
+
+        st.rerun()
 
 
 def _select_workspace(client, on_change) -> None:
@@ -80,6 +114,8 @@ if __name__ == "__main__":
             st.logo(app_settings.LOGO_LIGHT_URL)
         elif base == "dark" and app_settings.LOGO_DARK_URL:
             st.logo(app_settings.LOGO_DARK_URL)
+
+    check_organization_secret()
 
     pg = st.navigation(
         [

--- a/frontend/sdk/so_insights_client/api/organizations/get_organization.py
+++ b/frontend/sdk/so_insights_client/api/organizations/get_organization.py
@@ -1,0 +1,163 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.organization import Organization
+from ...types import Response
+
+
+def _get_kwargs(
+    organization_id: str,
+) -> Dict[str, Any]:
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": f"/organizations/{organization_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    if response.status_code == 200:
+        response_200 = Organization.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Organization]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    organization_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, Organization]]:
+    """Get Organization
+
+     Retrieve a single organization by ID.
+
+    Args:
+        organization_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Organization]]
+    """
+
+    kwargs = _get_kwargs(
+        organization_id=organization_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    organization_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    """Get Organization
+
+     Retrieve a single organization by ID.
+
+    Args:
+        organization_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Organization]
+    """
+
+    return sync_detailed(
+        organization_id=organization_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    organization_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, Organization]]:
+    """Get Organization
+
+     Retrieve a single organization by ID.
+
+    Args:
+        organization_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Organization]]
+    """
+
+    kwargs = _get_kwargs(
+        organization_id=organization_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    organization_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    """Get Organization
+
+     Retrieve a single organization by ID.
+
+    Args:
+        organization_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Organization]
+    """
+
+    return (
+        await asyncio_detailed(
+            organization_id=organization_id,
+            client=client,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/api/organizations/get_organization_by_secret_code.py
+++ b/frontend/sdk/so_insights_client/api/organizations/get_organization_by_secret_code.py
@@ -1,0 +1,175 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.organization import Organization
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    code: str,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+
+    params["code"] = code
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/organizations/by-secret-code",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    if response.status_code == 200:
+        response_200 = Organization.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Organization]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    code: str,
+) -> Response[Union[HTTPValidationError, Organization]]:
+    """Get Organization By Secret Code
+
+     Retrieve an organization by its secret code.
+    Returns 404 if none found.
+
+    Args:
+        code (str): Organization secret code
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Organization]]
+    """
+
+    kwargs = _get_kwargs(
+        code=code,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    code: str,
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    """Get Organization By Secret Code
+
+     Retrieve an organization by its secret code.
+    Returns 404 if none found.
+
+    Args:
+        code (str): Organization secret code
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Organization]
+    """
+
+    return sync_detailed(
+        client=client,
+        code=code,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    code: str,
+) -> Response[Union[HTTPValidationError, Organization]]:
+    """Get Organization By Secret Code
+
+     Retrieve an organization by its secret code.
+    Returns 404 if none found.
+
+    Args:
+        code (str): Organization secret code
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Organization]]
+    """
+
+    kwargs = _get_kwargs(
+        code=code,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    code: str,
+) -> Optional[Union[HTTPValidationError, Organization]]:
+    """Get Organization By Secret Code
+
+     Retrieve an organization by its secret code.
+    Returns 404 if none found.
+
+    Args:
+        code (str): Organization secret code
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Organization]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            code=code,
+        )
+    ).parsed

--- a/frontend/sdk/so_insights_client/models/__init__.py
+++ b/frontend/sdk/so_insights_client/models/__init__.py
@@ -16,6 +16,7 @@ from .ingestion_config_type import IngestionConfigType
 from .ingestion_run import IngestionRun
 from .language import Language
 from .list_clusters_for_session_relevance_levels_type_0_item import ListClustersForSessionRelevanceLevelsType0Item
+from .organization import Organization
 from .region import Region
 from .relevancy_filter import RelevancyFilter
 from .rss_ingestion_config import RssIngestionConfig
@@ -48,6 +49,7 @@ __all__ = (
     "IngestionRun",
     "Language",
     "ListClustersForSessionRelevanceLevelsType0Item",
+    "Organization",
     "Region",
     "RelevancyFilter",
     "RssIngestionConfig",

--- a/frontend/sdk/so_insights_client/models/organization.py
+++ b/frontend/sdk/so_insights_client/models/organization.py
@@ -1,0 +1,135 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Organization")
+
+
+@_attrs_define
+class Organization:
+    """Represents an organization within the SO Insights system.
+
+    Organizations group related workspaces and restrict access to them using a shared
+    secret code. Users must provide the correct secret code to access the workspaces
+    associated with an organization.
+
+    They are created by admins.
+
+    Warning:
+    This authentication mechanism is not designed for secure environments.
+    The secret code approach provides minimal security and should not be
+    relied upon for sensitive or confidential data. Consider using
+    more robust authentication methods for enhanced security.
+
+        Attributes:
+            name (str): Unique name of the organization
+            secret_code (str): Shared secret passphrase for access. Could be easy to guess, not secure.
+            field_id (Union[None, Unset, str]): MongoDB document ObjectID
+            created_at (Union[Unset, datetime.datetime]):
+            updated_at (Union[Unset, datetime.datetime]):
+    """
+
+    name: str
+    secret_code: str
+    field_id: Union[None, Unset, str] = UNSET
+    created_at: Union[Unset, datetime.datetime] = UNSET
+    updated_at: Union[Unset, datetime.datetime] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+
+        secret_code = self.secret_code
+
+        field_id: Union[None, Unset, str]
+        if isinstance(self.field_id, Unset):
+            field_id = UNSET
+        else:
+            field_id = self.field_id
+
+        created_at: Union[Unset, str] = UNSET
+        if not isinstance(self.created_at, Unset):
+            created_at = self.created_at.isoformat()
+
+        updated_at: Union[Unset, str] = UNSET
+        if not isinstance(self.updated_at, Unset):
+            updated_at = self.updated_at.isoformat()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "secret_code": secret_code,
+            }
+        )
+        if field_id is not UNSET:
+            field_dict["_id"] = field_id
+        if created_at is not UNSET:
+            field_dict["created_at"] = created_at
+        if updated_at is not UNSET:
+            field_dict["updated_at"] = updated_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        secret_code = d.pop("secret_code")
+
+        def _parse_field_id(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        field_id = _parse_field_id(d.pop("_id", UNSET))
+
+        _created_at = d.pop("created_at", UNSET)
+        created_at: Union[Unset, datetime.datetime]
+        if isinstance(_created_at, Unset):
+            created_at = UNSET
+        else:
+            created_at = isoparse(_created_at)
+
+        _updated_at = d.pop("updated_at", UNSET)
+        updated_at: Union[Unset, datetime.datetime]
+        if isinstance(_updated_at, Unset):
+            updated_at = UNSET
+        else:
+            updated_at = isoparse(_updated_at)
+
+        organization = cls(
+            name=name,
+            secret_code=secret_code,
+            field_id=field_id,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        organization.additional_properties = d
+        return organization
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/frontend/sdk/so_insights_client/models/workspace.py
+++ b/frontend/sdk/so_insights_client/models/workspace.py
@@ -22,7 +22,10 @@ class Workspace:
     A Workspace is like a container for a specific research topic or project. It holds
     settings and metadata that apply to all the content within it.
 
+    Each workspace belongs to an organization.
+
         Attributes:
+            organization_id (str): Reference to the organization that owns this workspace Example: 5eb7cf5a86d9755df3a6c593.
             name (str): The name of the workspace
             field_id (Union[None, Unset, str]): MongoDB document ObjectID
             description (Union[Unset, str]): A detailed description of the workspace's purpose Default: ''.
@@ -34,6 +37,7 @@ class Workspace:
                 Default: True.
     """
 
+    organization_id: str
     name: str
     field_id: Union[None, Unset, str] = UNSET
     description: Union[Unset, str] = ""
@@ -45,6 +49,8 @@ class Workspace:
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
+        organization_id = self.organization_id
+
         name = self.name
 
         field_id: Union[None, Unset, str]
@@ -77,6 +83,7 @@ class Workspace:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "organization_id": organization_id,
                 "name": name,
             }
         )
@@ -102,6 +109,8 @@ class Workspace:
         from ..models.hdbscan_settings import HdbscanSettings
 
         d = src_dict.copy()
+        organization_id = d.pop("organization_id")
+
         name = d.pop("name")
 
         def _parse_field_id(data: object) -> Union[None, Unset, str]:
@@ -146,6 +155,7 @@ class Workspace:
         enabled = d.pop("enabled", UNSET)
 
         workspace = cls(
+            organization_id=organization_id,
             name=name,
             field_id=field_id,
             description=description,

--- a/frontend/src/pages/chatbot.py
+++ b/frontend/src/pages/chatbot.py
@@ -9,7 +9,7 @@ from langchain_community.chat_message_histories import StreamlitChatMessageHisto
 from sdk.so_insights_client.api.starters import get_latest_starters
 from shared.set_of_unique_articles import SetOfUniqueArticles
 from src.app_settings import app_settings
-from src.shared import get_client, get_workspace_or_stop
+from src.shared import get_authenticated_client, get_workspace_or_stop
 import streamlit as st
 from langchain.chat_models import init_chat_model
 from langchain import hub
@@ -60,7 +60,7 @@ embeddings = VoyageAIEmbeddings(  # type:ignore #Arguments missing for parameter
 )
 
 
-client = get_client()
+client = get_authenticated_client(workspace.organization_id)
 
 if not st.session_state.get("session_id"):
     st.session_state["session_id"] = uuid4().hex

--- a/frontend/src/pages/content_studio.py
+++ b/frontend/src/pages/content_studio.py
@@ -17,16 +17,16 @@ from sdk.so_insights_client.models.workspace import Workspace
 from src.content_generation import create_social_media_content
 import streamlit as st
 from src.shared import (
+    get_authenticated_client,
     get_workspace_or_stop,
     language_to_str,
     select_session_or_stop,
-    get_client,
 )
 from langchain.chat_models import init_chat_model
 
 
-client = get_client()
 workspace = get_workspace_or_stop()
+client = get_authenticated_client(workspace.organization_id)
 
 
 def create_getimg_client():

--- a/frontend/src/pages/topics.py
+++ b/frontend/src/pages/topics.py
@@ -25,15 +25,15 @@ from sdk.so_insights_client.models.http_validation_error import HTTPValidationEr
 from src.shared import (
     create_toast,
     dates_to_session_label,
-    get_client,
+    get_authenticated_client,
     get_workspace_or_stop,
     select_session_or_stop,
     task_status_to_st_status,
 )
 from streamlit.elements.lib.mutable_status_container import StatusContainer
 
-client = get_client()
 workspace = get_workspace_or_stop()
+client = get_authenticated_client(workspace.organization_id)
 
 
 with st.sidebar:

--- a/frontend/src/pages/workspace.py
+++ b/frontend/src/pages/workspace.py
@@ -50,13 +50,13 @@ from shared.util import validate_url
 from src.app_settings import app_settings
 from src.shared import (
     create_toast,
-    get_client,
+    get_authenticated_client,
     language_to_str,
     task_status_to_st_status,
 )
 
 
-client = get_client()
+client = get_authenticated_client(st.session_state.organization_id)
 
 st.title("My Workspace")
 
@@ -69,6 +69,7 @@ def _get_language_index(language: Language) -> int:
 def region_to_full_name(region: Region) -> str:
     return shared.region.Region(region).get_full_name()
 
+
 def format_time_limit(time_limit: TimeLimit) -> str:
     return {
         TimeLimit.D: "1 Day",
@@ -76,6 +77,7 @@ def format_time_limit(time_limit: TimeLimit) -> str:
         TimeLimit.M: "1 Month",
         TimeLimit.Y: "1 Year",
     }[time_limit]
+
 
 @st.dialog("Create a new workspace")
 def _create_new_workspace_dialog():
@@ -832,10 +834,12 @@ def _history_section(workspace: Workspace):
         st.write(f"+{len(runs) - MAX_RUNS_TO_DISPLAY} more")
 
 
-
-
 def _workspace_dialog_action(workspace: Workspace, *, action: str, enabled_value: bool):
-    text = "Enabling the workspace will resume monitoring news articles." if enabled_value else "Disabling the workspace will stop monitoring news articles."
+    text = (
+        "Enabling the workspace will resume monitoring news articles."
+        if enabled_value
+        else "Disabling the workspace will stop monitoring news articles."
+    )
 
     st.warning(text, icon="⚠️")
 
@@ -853,13 +857,16 @@ def _workspace_dialog_action(workspace: Workspace, *, action: str, enabled_value
         else:
             st.error(f"Failed to {action.lower()} workspace. Error: {response}")
 
+
 @st.dialog("Disable Workspace")
 def _disable_workspace_dialog(workspace: Workspace):
     _workspace_dialog_action(workspace, action="Disable", enabled_value=False)
 
+
 @st.dialog("Enable Workspace")
 def _enable_workspace_dialog(workspace: Workspace):
     _workspace_dialog_action(workspace, action="Enable", enabled_value=True)
+
 
 def toggle_workspace_enabled_button(workspace: Workspace):
     """
@@ -885,7 +892,7 @@ def toggle_workspace_enabled_button(workspace: Workspace):
         use_container_width=True,
     ):
         dialog_function(workspace)
-        
+
 
 if st.sidebar.button("➕Create New Workspace", use_container_width=True):
     _create_new_workspace_dialog()

--- a/frontend/src/shared.py
+++ b/frontend/src/shared.py
@@ -15,8 +15,23 @@ from sdk.so_insights_client.models.status import Status
 
 
 @st.cache_resource
-def get_client():
+def get_client() -> Client:
     return Client(base_url=app_settings.SO_INSIGHTS_API_URL)
+
+
+@st.cache_resource
+def get_authenticated_client(organization_id: str) -> Client:
+    """This function returns a client with the organization ID set in the headers.
+    The organization_id serves as a way to authenticate the client with the API,
+    in a very insecure way.
+
+    The organization_id can be obtained by exchanging with a secret code.
+    """
+
+    return Client(
+        base_url=app_settings.SO_INSIGHTS_API_URL,
+        headers={"X-Organization-ID": organization_id},
+    )
 
 
 def get_workspace_or_stop() -> Workspace:

--- a/ingester/README.md
+++ b/ingester/README.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-The SO Insights Ingester is a crucial component of the SO Insights project, designed to collect, process, and store articles from various online sources. It performs web searches and RSS feed ingestion based on predefined queries and configurations, storing the results in both MongoDB and Pinecone vector database for efficient retrieval and analysis.
+The SO Insights Ingester collects, processes, and stores articles from various online sources. It performs web searches using either DuckDuckGo or Serper.dev and handles RSS feed ingestion, storing the results in MongoDB and Pinecone for efficient retrieval and analysis.
 
 ## Features
 
-- Asynchronous web searching using DuckDuckGo
+- Asynchronous web searching using DuckDuckGo or Serper.dev
 - RSS feed ingestion
 - Storage in MongoDB for structured data
 - Indexing in Pinecone for vector search capabilities
@@ -19,6 +19,7 @@ The SO Insights Ingester is a crucial component of the SO Insights project, desi
 - MongoDB
 - Pinecone account
 - VoyageAI API access
+- Serper.dev API key (if using Serper.dev as the search provider)
 
 ## Installation
 
@@ -64,24 +65,8 @@ The Ingester provides several command-line interfaces:
    poetry run python main.py watch [--interval <seconds>] [--max-runtime <seconds>]
    ```
 
-## Project Structure
 
-```
-ingester
-├── main.py               # Main entry point and CLI commands
-├── pyproject.toml        # Project configuration and dependencies
-├── README.md             # Project documentation
-├── src
-│   ├── ingester_settings.py     # Configuration settings
-│   ├── mongo_db_operations.py   # MongoDB operations
-│   ├── rss.py                   # RSS feed ingestion
-│   ├── search.py                # Web search functionality
-│   ├── vector_indexing.py       # Vector database operations
-│   └── __init__.py
-└── tests
-    ├── test_rss.py              # Tests for RSS functionality
-    └── __init__.py
-```
+The choice of search provider can be configured using the `SEARCH_PROVIDER` environment variable. 
 
 ## Core Functionalities
 

--- a/shared/shared/db.py
+++ b/shared/shared/db.py
@@ -11,6 +11,7 @@ from shared.models import (
     ClusteringSession,
     IngestionConfig,
     IngestionRun,
+    Organization,
     RssIngestionConfig,
     SearchIngestionConfig,
     Starters,
@@ -35,6 +36,7 @@ async def my_init_beanie(client):
     await init_beanie(
         database=client[db_settings.mongodb_database],
         document_models=[
+            Organization,
             Workspace,
             IngestionConfig,
             SearchIngestionConfig,

--- a/shared/shared/db_settings.py
+++ b/shared/shared/db_settings.py
@@ -17,6 +17,7 @@ class DBSettings(BaseSettings):
     mongodb_clustering_sessions_collection: str = "clustering_sessions"
     mongodb_starters_collection: str = "starters"
     mongodb_ingestion_configs_collection: str = "ingestion_configs"
+    mongodb_organizations_collection: str = "organizations"
 
 
 db_settings = DBSettings()


### PR DESCRIPTION
<img width="966" alt="image" src="https://github.com/user-attachments/assets/21af9c8b-3cf6-422f-a1e6-ea33c9c5095b" />

Previously, all workspaces were visible to all users. Here we implement a simple Organizations and Authentication feature with Secret Code. 

- Administrators can create Organisations in the database.
- Each Organisation has a name and a secret code.
- Each workspace is linked to an organisation.
- Only users knowing the organisation’s secret code can access the workspaces linked to the organization.
- The frontend’s landing page show a text input for the secret code. When users enter the secret code for an organization, they can use the app.
- Each secret code is unique. (No 2 workspaces with the same secret code)

**Warning : This is highly insecure and should not be used to protect confidential data : **
- Secret Codes are stored in plain text in both DB and maybe the browser
- The front exchanges the secret code against the organization's ID. We wrongly assume that the org ID can't be guessed, and dangerously use it for authentication. 

Once the frontend obtained the Organization ID, it must provide a `X-Organization-ID` header in each request which is verified in the backend before returning resources. 