### PR TITLE
Feat/full content fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SO Insights consists of four main components:
 
 The Ingester component is responsible for:
 - Performing web searches to online news sources based on user predefined queries
+- Fetches full content of articles and cleans it using LLM.
 - Ingesting articles from RSS feeds
 - Coming soon : Ingesting data from Twitter, Linkedin.. 
 - Storing articles in MongoDB and indexing them in Pinecone

--- a/analyzer/src/analyzer_settings.py
+++ b/analyzer/src/analyzer_settings.py
@@ -23,6 +23,7 @@ class AnalyzerSettings(BaseSettings):
 
     OVERVIEW_GENERATION_MAX_ARTICLES: int = 30
     OVERVIEW_GENERATION_MAX_CONCURRENCY: int = 5
+    OVERVIEW_GENERATION_INCLUDE_CONTENTS: bool = True
 
     # when the number of clusters found is less than this value
     # we will also include the clusters summaries (instead of just the titles)

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -15,10 +15,24 @@ from shared.models import (
 )
 
 
-async def get_organization(x_organization_id: Annotated[str, Header()]) -> Organization:
+async def get_organization(
+    x_organization_id: Annotated[str | None, Header()] = None,
+) -> Organization:
+    """
+    Get organization by X-Organization-ID header.
+
+    x_organization_id is set to None by default so the generated python sdk won't
+    require it to be passed in every function call, but can be passed once when
+    creating the client.
+    """
+    if not x_organization_id:
+        raise HTTPException(status_code=400, detail="X-Organization-ID header missing")
+
     organization = await Organization.get(x_organization_id)
+
     if not organization:
         raise HTTPException(status_code=400, detail="Invalid X-Organization-ID header")
+
     assert organization.id
     return organization
 

--- a/backend/src/routers/organizations.py
+++ b/backend/src/routers/organizations.py
@@ -1,7 +1,7 @@
+from beanie import PydanticObjectId
 from fastapi import APIRouter, HTTPException, Query
 
 from shared.models import Organization
-from src.dependencies import ExistingOrganization
 
 router = APIRouter(tags=["organizations"])
 
@@ -78,8 +78,11 @@ async def get_organization_by_secret_code(
     response_model=Organization,
     operation_id="get_organization",
 )
-async def get_organization(organization: ExistingOrganization):
+async def get_organization(organization_id: str | PydanticObjectId):
     """
     Retrieve a single organization by ID.
     """
-    return organization
+    org = await Organization.get(organization_id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    return org

--- a/backend/src/routers/organizations.py
+++ b/backend/src/routers/organizations.py
@@ -1,10 +1,7 @@
-from fastapi import APIRouter, HTTPException, Query, status
-from pydantic import SecretStr
-from pymongo.errors import DuplicateKeyError
+from fastapi import APIRouter, HTTPException, Query
 
 from shared.models import Organization
 from src.dependencies import ExistingOrganization
-from src.schemas import OrganizationCreate
 
 router = APIRouter(tags=["organizations"])
 

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -6,7 +6,6 @@ from pydantic import (
     Field,
     HttpUrl,
     PastDatetime,
-    SecretStr,
     StringConstraints,
 )
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -10,6 +10,14 @@ import streamlit as st
 from streamlit_theme import st_theme
 
 
+settings_page = st.Page("src/pages/settings.py", title="Settings", icon="⚙️")
+topics_page = st.Page("src/pages/topics.py", title="Topics", icon="🔎", default=True)
+content_studio_page = st.Page(
+    "src/pages/content_studio.py", title="Content Studio", icon="✍️"
+)
+chatbot_page = st.Page("src/pages/chatbot.py", title="Chatbot", icon="💬")
+
+
 def check_organization_secret():
     """
     Validates and logs the user into an organization using a secret code.
@@ -100,7 +108,15 @@ def _select_workspace(client, on_change) -> None:
     assert all(isinstance(w, Workspace) for w in workspaces)
 
     if not workspaces:
-        st.warning("No workspaces found. Start by creating a new workspace.")
+        # explain to go into settings tab to create a workspace
+        st.warning(
+            "No workspaces found. Start by creating a new workspace in the Settings tab."
+        )
+        if (  # if the current page is not the settings page, show a button to go to settings
+            st.session_state.current_page.title != settings_page.title
+            and st.sidebar.button("⚙️ Go to Settings", use_container_width=True)
+        ):
+            st.switch_page(settings_page)
         return None
 
     index = 0
@@ -151,12 +167,13 @@ if __name__ == "__main__":
 
     pg = st.navigation(
         [
-            st.Page("src/pages/settings.py", title="Settings", icon="⚙️"),
-            st.Page("src/pages/topics.py", title="Topics", icon="🔎", default=True),
-            st.Page("src/pages/content_studio.py", title="Content Studio", icon="✍️"),
-            st.Page("src/pages/chatbot.py", title="Chatbot", icon="💬"),
+            settings_page,
+            topics_page,
+            content_studio_page,
+            chatbot_page,
         ]
     )
+    st.session_state.current_page = pg
 
     def _on_workspace_change():
         if chatbot_callback := st.session_state.get("on_workspace_changed_chatbot"):

--- a/frontend/sdk/so_insights_client/api/clustering/create_clustering_session.py
+++ b/frontend/sdk/so_insights_client/api/clustering/create_clustering_session.py
@@ -8,15 +8,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.clustering_session import ClusteringSession
 from ...models.clustering_session_create import ClusteringSessionCreate
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     *,
     body: ClusteringSessionCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "post",
@@ -35,11 +38,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = ClusteringSession.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -65,6 +68,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusteringSessionCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[ClusteringSession, HTTPValidationError]]:
     """Create Clustering Session
 
@@ -72,6 +76,7 @@ def sync_detailed(
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusteringSessionCreate):
 
     Raises:
@@ -85,6 +90,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -99,6 +105,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusteringSessionCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
     """Create Clustering Session
 
@@ -106,6 +113,7 @@ def sync(
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusteringSessionCreate):
 
     Raises:
@@ -120,6 +128,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -128,6 +137,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusteringSessionCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[ClusteringSession, HTTPValidationError]]:
     """Create Clustering Session
 
@@ -135,6 +145,7 @@ async def asyncio_detailed(
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusteringSessionCreate):
 
     Raises:
@@ -148,6 +159,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -160,6 +172,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusteringSessionCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
     """Create Clustering Session
 
@@ -167,6 +180,7 @@ async def asyncio(
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusteringSessionCreate):
 
     Raises:
@@ -182,5 +196,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/delete_cluster_feedback.py
+++ b/frontend/sdk/so_insights_client/api/clustering/delete_cluster_feedback.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cluster import Cluster
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     cluster_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "delete",
         "url": f"/workspaces/{workspace_id}/clustering/clusters/{cluster_id}/feedback",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = Cluster.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,6 +62,7 @@ def sync_detailed(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Delete Cluster Feedback
 
@@ -63,6 +71,7 @@ def sync_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -75,6 +84,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -89,6 +99,7 @@ def sync(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Delete Cluster Feedback
 
@@ -97,6 +108,7 @@ def sync(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -110,6 +122,7 @@ def sync(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -118,6 +131,7 @@ async def asyncio_detailed(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Delete Cluster Feedback
 
@@ -126,6 +140,7 @@ async def asyncio_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -138,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -150,6 +166,7 @@ async def asyncio(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Delete Cluster Feedback
 
@@ -158,6 +175,7 @@ async def asyncio(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,5 +190,6 @@ async def asyncio(
             workspace_id=workspace_id,
             cluster_id=cluster_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/get_cluster.py
+++ b/frontend/sdk/so_insights_client/api/clustering/get_cluster.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cluster import Cluster
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     cluster_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/clustering/clusters/{cluster_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = Cluster.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,6 +62,7 @@ def sync_detailed(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Get Cluster
 
@@ -63,6 +71,7 @@ def sync_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -75,6 +84,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -89,6 +99,7 @@ def sync(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Get Cluster
 
@@ -97,6 +108,7 @@ def sync(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -110,6 +122,7 @@ def sync(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -118,6 +131,7 @@ async def asyncio_detailed(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Get Cluster
 
@@ -126,6 +140,7 @@ async def asyncio_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -138,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -150,6 +166,7 @@ async def asyncio(
     cluster_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Get Cluster
 
@@ -158,6 +175,7 @@ async def asyncio(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,5 +190,6 @@ async def asyncio(
             workspace_id=workspace_id,
             cluster_id=cluster_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/get_clustering_session.py
+++ b/frontend/sdk/so_insights_client/api/clustering/get_clustering_session.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.clustering_session import ClusteringSession
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     session_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/clustering/sessions/{session_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = ClusteringSession.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,6 +62,7 @@ def sync_detailed(
     session_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[ClusteringSession, HTTPValidationError]]:
     """Get Clustering Session
 
@@ -63,6 +71,7 @@ def sync_detailed(
     Args:
         workspace_id (str):
         session_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -75,6 +84,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         session_id=session_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -89,6 +99,7 @@ def sync(
     session_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
     """Get Clustering Session
 
@@ -97,6 +108,7 @@ def sync(
     Args:
         workspace_id (str):
         session_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -110,6 +122,7 @@ def sync(
         workspace_id=workspace_id,
         session_id=session_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -118,6 +131,7 @@ async def asyncio_detailed(
     session_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[ClusteringSession, HTTPValidationError]]:
     """Get Clustering Session
 
@@ -126,6 +140,7 @@ async def asyncio_detailed(
     Args:
         workspace_id (str):
         session_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -138,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         session_id=session_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -150,6 +166,7 @@ async def asyncio(
     session_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[ClusteringSession, HTTPValidationError]]:
     """Get Clustering Session
 
@@ -158,6 +175,7 @@ async def asyncio(
     Args:
         workspace_id (str):
         session_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,5 +190,6 @@ async def asyncio(
             workspace_id=workspace_id,
             session_id=session_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/list_clustering_sessions.py
+++ b/frontend/sdk/so_insights_client/api/clustering/list_clustering_sessions.py
@@ -15,7 +15,12 @@ def _get_kwargs(
     workspace_id: str,
     *,
     statuses: Union[List[Status], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     params: Dict[str, Any] = {}
 
     json_statuses: Union[List[str], None, Unset]
@@ -39,13 +44,14 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["ClusteringSession"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -54,7 +60,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -80,6 +86,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     statuses: Union[List[Status], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["ClusteringSession"]]]:
     """List Clustering Sessions
 
@@ -88,6 +95,7 @@ def sync_detailed(
     Args:
         workspace_id (str):
         statuses (Union[List[Status], None, Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -100,6 +108,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         statuses=statuses,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -114,6 +123,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     statuses: Union[List[Status], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["ClusteringSession"]]]:
     """List Clustering Sessions
 
@@ -122,6 +132,7 @@ def sync(
     Args:
         workspace_id (str):
         statuses (Union[List[Status], None, Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -135,6 +146,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         statuses=statuses,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -143,6 +155,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     statuses: Union[List[Status], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["ClusteringSession"]]]:
     """List Clustering Sessions
 
@@ -151,6 +164,7 @@ async def asyncio_detailed(
     Args:
         workspace_id (str):
         statuses (Union[List[Status], None, Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -163,6 +177,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         statuses=statuses,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -175,6 +190,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     statuses: Union[List[Status], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["ClusteringSession"]]]:
     """List Clustering Sessions
 
@@ -183,6 +199,7 @@ async def asyncio(
     Args:
         workspace_id (str):
         statuses (Union[List[Status], None, Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -197,5 +214,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             statuses=statuses,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/list_clusters_for_session.py
+++ b/frontend/sdk/so_insights_client/api/clustering/list_clusters_for_session.py
@@ -18,7 +18,12 @@ def _get_kwargs(
     session_id: str,
     *,
     relevance_levels: Union[List[ListClustersForSessionRelevanceLevelsType0Item], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     params: Dict[str, Any] = {}
 
     json_relevance_levels: Union[List[str], None, Unset]
@@ -42,13 +47,14 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["Cluster"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -57,7 +63,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -84,6 +90,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     relevance_levels: Union[List[ListClustersForSessionRelevanceLevelsType0Item], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["Cluster"]]]:
     """List Clusters
 
@@ -94,6 +101,7 @@ def sync_detailed(
         session_id (str):
         relevance_levels (Union[List[ListClustersForSessionRelevanceLevelsType0Item], None,
             Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +115,7 @@ def sync_detailed(
         workspace_id=workspace_id,
         session_id=session_id,
         relevance_levels=relevance_levels,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -122,6 +131,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     relevance_levels: Union[List[ListClustersForSessionRelevanceLevelsType0Item], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["Cluster"]]]:
     """List Clusters
 
@@ -132,6 +142,7 @@ def sync(
         session_id (str):
         relevance_levels (Union[List[ListClustersForSessionRelevanceLevelsType0Item], None,
             Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -146,6 +157,7 @@ def sync(
         session_id=session_id,
         client=client,
         relevance_levels=relevance_levels,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -155,6 +167,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     relevance_levels: Union[List[ListClustersForSessionRelevanceLevelsType0Item], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["Cluster"]]]:
     """List Clusters
 
@@ -165,6 +178,7 @@ async def asyncio_detailed(
         session_id (str):
         relevance_levels (Union[List[ListClustersForSessionRelevanceLevelsType0Item], None,
             Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -178,6 +192,7 @@ async def asyncio_detailed(
         workspace_id=workspace_id,
         session_id=session_id,
         relevance_levels=relevance_levels,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -191,6 +206,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     relevance_levels: Union[List[ListClustersForSessionRelevanceLevelsType0Item], None, Unset] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["Cluster"]]]:
     """List Clusters
 
@@ -201,6 +217,7 @@ async def asyncio(
         session_id (str):
         relevance_levels (Union[List[ListClustersForSessionRelevanceLevelsType0Item], None,
             Unset]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -216,5 +233,6 @@ async def asyncio(
             session_id=session_id,
             client=client,
             relevance_levels=relevance_levels,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/list_clusters_with_articles_for_session.py
+++ b/frontend/sdk/so_insights_client/api/clustering/list_clusters_with_articles_for_session.py
@@ -17,7 +17,12 @@ def _get_kwargs(
     *,
     relevancy_filter: Union[Unset, RelevancyFilter] = RelevancyFilter.ALL,
     n_articles: Union[Unset, int] = 5,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     params: Dict[str, Any] = {}
 
     json_relevancy_filter: Union[Unset, str] = UNSET
@@ -36,13 +41,14 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["ClusterWithArticles"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -51,7 +57,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -79,6 +85,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     relevancy_filter: Union[Unset, RelevancyFilter] = RelevancyFilter.ALL,
     n_articles: Union[Unset, int] = 5,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["ClusterWithArticles"]]]:
     """List Clusters With Articles
 
@@ -89,6 +96,7 @@ def sync_detailed(
         session_id (str):
         relevancy_filter (Union[Unset, RelevancyFilter]):  Default: RelevancyFilter.ALL.
         n_articles (Union[Unset, int]):  Default: 5.
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,6 +111,7 @@ def sync_detailed(
         session_id=session_id,
         relevancy_filter=relevancy_filter,
         n_articles=n_articles,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -119,6 +128,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     relevancy_filter: Union[Unset, RelevancyFilter] = RelevancyFilter.ALL,
     n_articles: Union[Unset, int] = 5,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["ClusterWithArticles"]]]:
     """List Clusters With Articles
 
@@ -129,6 +139,7 @@ def sync(
         session_id (str):
         relevancy_filter (Union[Unset, RelevancyFilter]):  Default: RelevancyFilter.ALL.
         n_articles (Union[Unset, int]):  Default: 5.
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,6 +155,7 @@ def sync(
         client=client,
         relevancy_filter=relevancy_filter,
         n_articles=n_articles,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -154,6 +166,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     relevancy_filter: Union[Unset, RelevancyFilter] = RelevancyFilter.ALL,
     n_articles: Union[Unset, int] = 5,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["ClusterWithArticles"]]]:
     """List Clusters With Articles
 
@@ -164,6 +177,7 @@ async def asyncio_detailed(
         session_id (str):
         relevancy_filter (Union[Unset, RelevancyFilter]):  Default: RelevancyFilter.ALL.
         n_articles (Union[Unset, int]):  Default: 5.
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -178,6 +192,7 @@ async def asyncio_detailed(
         session_id=session_id,
         relevancy_filter=relevancy_filter,
         n_articles=n_articles,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -192,6 +207,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     relevancy_filter: Union[Unset, RelevancyFilter] = RelevancyFilter.ALL,
     n_articles: Union[Unset, int] = 5,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["ClusterWithArticles"]]]:
     """List Clusters With Articles
 
@@ -202,6 +218,7 @@ async def asyncio(
         session_id (str):
         relevancy_filter (Union[Unset, RelevancyFilter]):  Default: RelevancyFilter.ALL.
         n_articles (Union[Unset, int]):  Default: 5.
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -218,5 +235,6 @@ async def asyncio(
             client=client,
             relevancy_filter=relevancy_filter,
             n_articles=n_articles,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/clustering/set_cluster_feedback.py
+++ b/frontend/sdk/so_insights_client/api/clustering/set_cluster_feedback.py
@@ -8,7 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.cluster import Cluster
 from ...models.cluster_feedback import ClusterFeedback
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -16,8 +16,11 @@ def _get_kwargs(
     cluster_id: str,
     *,
     body: ClusterFeedback,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "put",
@@ -36,11 +39,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = Cluster.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -67,6 +70,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusterFeedback,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Set Cluster Feedback
 
@@ -75,6 +79,7 @@ def sync_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusterFeedback): Captures user feedback on the relevance or usefulness of a
             cluster.
 
@@ -95,6 +100,7 @@ def sync_detailed(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -110,6 +116,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusterFeedback,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Set Cluster Feedback
 
@@ -118,6 +125,7 @@ def sync(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusterFeedback): Captures user feedback on the relevance or usefulness of a
             cluster.
 
@@ -139,6 +147,7 @@ def sync(
         cluster_id=cluster_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -148,6 +157,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusterFeedback,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Cluster, HTTPValidationError]]:
     """Set Cluster Feedback
 
@@ -156,6 +166,7 @@ async def asyncio_detailed(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusterFeedback): Captures user feedback on the relevance or usefulness of a
             cluster.
 
@@ -176,6 +187,7 @@ async def asyncio_detailed(
         workspace_id=workspace_id,
         cluster_id=cluster_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -189,6 +201,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ClusterFeedback,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Cluster, HTTPValidationError]]:
     """Set Cluster Feedback
 
@@ -197,6 +210,7 @@ async def asyncio(
     Args:
         workspace_id (str):
         cluster_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (ClusterFeedback): Captures user feedback on the relevance or usefulness of a
             cluster.
 
@@ -219,5 +233,6 @@ async def asyncio(
             cluster_id=cluster_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/default/root_get.py
+++ b/frontend/sdk/so_insights_client/api/default/root_get.py
@@ -18,7 +18,7 @@ def _get_kwargs() -> Dict[str, Any]:
 
 
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         return None
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/create_rss_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/create_rss_ingestion_config.py
@@ -8,15 +8,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rss_ingestion_config import RssIngestionConfig
 from ...models.rss_ingestion_config_create import RssIngestionConfigCreate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     *,
     body: RssIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "post",
@@ -35,11 +38,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
-    if response.status_code == HTTPStatus.CREATED:
+    if response.status_code == 201:
         response_201 = RssIngestionConfig.from_dict(response.json())
 
         return response_201
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -65,11 +68,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Create Rss Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigCreate):
 
     Raises:
@@ -83,6 +88,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,11 +103,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Create Rss Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigCreate):
 
     Raises:
@@ -116,6 +124,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -124,11 +133,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Create Rss Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigCreate):
 
     Raises:
@@ -142,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,11 +166,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Create Rss Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigCreate):
 
     Raises:
@@ -174,5 +188,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/create_search_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/create_search_ingestion_config.py
@@ -8,15 +8,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.search_ingestion_config import SearchIngestionConfig
 from ...models.search_ingestion_config_create import SearchIngestionConfigCreate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     *,
     body: SearchIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "post",
@@ -35,11 +38,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
-    if response.status_code == HTTPStatus.CREATED:
+    if response.status_code == 201:
         response_201 = SearchIngestionConfig.from_dict(response.json())
 
         return response_201
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -65,11 +68,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Create Search Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigCreate):
 
     Raises:
@@ -83,6 +88,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,11 +103,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Create Search Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigCreate):
 
     Raises:
@@ -116,6 +124,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -124,11 +133,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Create Search Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigCreate):
 
     Raises:
@@ -142,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,11 +166,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Create Search Ingestion Config
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigCreate):
 
     Raises:
@@ -174,5 +188,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/get_rss_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/get_rss_ingestion_config.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rss_ingestion_config import RssIngestionConfig
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     rss_ingestion_config_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-configs/rss/{rss_ingestion_config_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = RssIngestionConfig.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,12 +62,14 @@ def sync_detailed(
     rss_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Get Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -73,6 +82,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         rss_ingestion_config_id=rss_ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,12 +97,14 @@ def sync(
     rss_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Get Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -106,6 +118,7 @@ def sync(
         workspace_id=workspace_id,
         rss_ingestion_config_id=rss_ingestion_config_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -114,12 +127,14 @@ async def asyncio_detailed(
     rss_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Get Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -132,6 +147,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         rss_ingestion_config_id=rss_ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -144,12 +160,14 @@ async def asyncio(
     rss_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Get Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -164,5 +182,6 @@ async def asyncio(
             workspace_id=workspace_id,
             rss_ingestion_config_id=rss_ingestion_config_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/get_search_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/get_search_ingestion_config.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.search_ingestion_config import SearchIngestionConfig
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     search_ingestion_config_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-configs/search/{search_ingestion_config_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = SearchIngestionConfig.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,12 +62,14 @@ def sync_detailed(
     search_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Get Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -73,6 +82,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         search_ingestion_config_id=search_ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,12 +97,14 @@ def sync(
     search_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Get Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -106,6 +118,7 @@ def sync(
         workspace_id=workspace_id,
         search_ingestion_config_id=search_ingestion_config_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -114,12 +127,14 @@ async def asyncio_detailed(
     search_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Get Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -132,6 +147,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         search_ingestion_config_id=search_ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -144,12 +160,14 @@ async def asyncio(
     search_ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Get Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -164,5 +182,6 @@ async def asyncio(
             workspace_id=workspace_id,
             search_ingestion_config_id=search_ingestion_config_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/list_ingestion_configs.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/list_ingestion_configs.py
@@ -8,24 +8,31 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rss_ingestion_config import RssIngestionConfig
 from ...models.search_ingestion_config import SearchIngestionConfig
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-configs/",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List[Union["RssIngestionConfig", "SearchIngestionConfig"]]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -50,7 +57,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -75,11 +82,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List[Union["RssIngestionConfig", "SearchIngestionConfig"]]]]:
     """List Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -91,6 +100,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -104,11 +114,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List[Union["RssIngestionConfig", "SearchIngestionConfig"]]]]:
     """List Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -121,6 +133,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -128,11 +141,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List[Union["RssIngestionConfig", "SearchIngestionConfig"]]]]:
     """List Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,6 +159,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -155,11 +171,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List[Union["RssIngestionConfig", "SearchIngestionConfig"]]]]:
     """List Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +191,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/list_rss_ingestion_configs.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/list_rss_ingestion_configs.py
@@ -7,24 +7,31 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rss_ingestion_config import RssIngestionConfig
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-configs/rss",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["RssIngestionConfig"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -33,7 +40,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -58,11 +65,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["RssIngestionConfig"]]]:
     """List Rss Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -74,6 +83,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,11 +97,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["RssIngestionConfig"]]]:
     """List Rss Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,6 +116,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -111,11 +124,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["RssIngestionConfig"]]]:
     """List Rss Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,6 +142,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -138,11 +154,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["RssIngestionConfig"]]]:
     """List Rss Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,5 +174,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/list_search_ingestion_configs.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/list_search_ingestion_configs.py
@@ -7,24 +7,31 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.search_ingestion_config import SearchIngestionConfig
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-configs/search",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["SearchIngestionConfig"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -33,7 +40,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -58,11 +65,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["SearchIngestionConfig"]]]:
     """List Search Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -74,6 +83,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,11 +97,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["SearchIngestionConfig"]]]:
     """List Search Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,6 +116,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -111,11 +124,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["SearchIngestionConfig"]]]:
     """List Search Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,6 +142,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -138,11 +154,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["SearchIngestionConfig"]]]:
     """List Search Ingestion Configs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,5 +174,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/update_rss_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/update_rss_ingestion_config.py
@@ -8,7 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rss_ingestion_config import RssIngestionConfig
 from ...models.rss_ingestion_config_update import RssIngestionConfigUpdate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -16,8 +16,11 @@ def _get_kwargs(
     rss_ingestion_config_id: str,
     *,
     body: RssIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "put",
@@ -36,11 +39,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = RssIngestionConfig.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -67,12 +70,14 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Update Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigUpdate):
 
     Raises:
@@ -87,6 +92,7 @@ def sync_detailed(
         workspace_id=workspace_id,
         rss_ingestion_config_id=rss_ingestion_config_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -102,12 +108,14 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Update Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigUpdate):
 
     Raises:
@@ -123,6 +131,7 @@ def sync(
         rss_ingestion_config_id=rss_ingestion_config_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -132,12 +141,14 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, RssIngestionConfig]]:
     """Update Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigUpdate):
 
     Raises:
@@ -152,6 +163,7 @@ async def asyncio_detailed(
         workspace_id=workspace_id,
         rss_ingestion_config_id=rss_ingestion_config_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -165,12 +177,14 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: RssIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, RssIngestionConfig]]:
     """Update Rss Ingestion Config
 
     Args:
         workspace_id (str):
         rss_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (RssIngestionConfigUpdate):
 
     Raises:
@@ -187,5 +201,6 @@ async def asyncio(
             rss_ingestion_config_id=rss_ingestion_config_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_configs/update_search_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_configs/update_search_ingestion_config.py
@@ -8,7 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.search_ingestion_config import SearchIngestionConfig
 from ...models.search_ingestion_config_update import SearchIngestionConfigUpdate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -16,8 +16,11 @@ def _get_kwargs(
     search_ingestion_config_id: str,
     *,
     body: SearchIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "put",
@@ -36,11 +39,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = SearchIngestionConfig.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -67,12 +70,14 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Update Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigUpdate):
 
     Raises:
@@ -87,6 +92,7 @@ def sync_detailed(
         workspace_id=workspace_id,
         search_ingestion_config_id=search_ingestion_config_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -102,12 +108,14 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Update Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigUpdate):
 
     Raises:
@@ -123,6 +131,7 @@ def sync(
         search_ingestion_config_id=search_ingestion_config_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -132,12 +141,14 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Update Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigUpdate):
 
     Raises:
@@ -152,6 +163,7 @@ async def asyncio_detailed(
         workspace_id=workspace_id,
         search_ingestion_config_id=search_ingestion_config_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -165,12 +177,14 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchIngestionConfigUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, SearchIngestionConfig]]:
     """Update Search Ingestion Config
 
     Args:
         workspace_id (str):
         search_ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (SearchIngestionConfigUpdate):
 
     Raises:
@@ -187,5 +201,6 @@ async def asyncio(
             search_ingestion_config_id=search_ingestion_config_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_runs/create_ingestion_run.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_runs/create_ingestion_run.py
@@ -7,14 +7,19 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.ingestion_run import IngestionRun
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     *,
     ingestion_config_id: str,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     params: Dict[str, Any] = {}
 
     json_ingestion_config_id: str
@@ -29,17 +34,18 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = IngestionRun.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -65,12 +71,14 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     ingestion_config_id: str,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, IngestionRun]]:
     """Create Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -83,6 +91,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_config_id=ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,12 +106,14 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     ingestion_config_id: str,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
     """Create Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -116,6 +127,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         ingestion_config_id=ingestion_config_id,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -124,12 +136,14 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     ingestion_config_id: str,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, IngestionRun]]:
     """Create Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +156,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_config_id=ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,12 +169,14 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     ingestion_config_id: str,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
     """Create Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -174,5 +191,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             ingestion_config_id=ingestion_config_id,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_runs/get_ingestion_run.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_runs/get_ingestion_run.py
@@ -7,29 +7,36 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.ingestion_run import IngestionRun
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     ingestion_run_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-runs/{ingestion_run_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = IngestionRun.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -55,12 +62,14 @@ def sync_detailed(
     ingestion_run_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, IngestionRun]]:
     """Get Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_run_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -73,6 +82,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_run_id=ingestion_run_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,12 +97,14 @@ def sync(
     ingestion_run_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
     """Get Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_run_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -106,6 +118,7 @@ def sync(
         workspace_id=workspace_id,
         ingestion_run_id=ingestion_run_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -114,12 +127,14 @@ async def asyncio_detailed(
     ingestion_run_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, IngestionRun]]:
     """Get Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_run_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -132,6 +147,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_run_id=ingestion_run_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -144,12 +160,14 @@ async def asyncio(
     ingestion_run_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, IngestionRun]]:
     """Get Ingestion Run
 
     Args:
         workspace_id (str):
         ingestion_run_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -164,5 +182,6 @@ async def asyncio(
             workspace_id=workspace_id,
             ingestion_run_id=ingestion_run_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_runs/list_ingestion_runs.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_runs/list_ingestion_runs.py
@@ -7,24 +7,31 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.ingestion_run import IngestionRun
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-runs/",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -33,7 +40,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -58,11 +65,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -74,6 +83,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -87,11 +97,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,6 +116,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -111,11 +124,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,6 +142,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -138,11 +154,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,5 +174,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/ingestion_runs/list_ingestion_runs_for_ingestion_config.py
+++ b/frontend/sdk/so_insights_client/api/ingestion_runs/list_ingestion_runs_for_ingestion_config.py
@@ -7,25 +7,32 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.ingestion_run import IngestionRun
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     ingestion_config_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/ingestion-runs/ingestion_config/{ingestion_config_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -34,7 +41,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -60,12 +67,14 @@ def sync_detailed(
     ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs For Ingestion Config
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -78,6 +87,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_config_id=ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -92,12 +102,14 @@ def sync(
     ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs For Ingestion Config
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -111,6 +123,7 @@ def sync(
         workspace_id=workspace_id,
         ingestion_config_id=ingestion_config_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -119,12 +132,14 @@ async def asyncio_detailed(
     ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs For Ingestion Config
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -137,6 +152,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         ingestion_config_id=ingestion_config_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -149,12 +165,14 @@ async def asyncio(
     ingestion_config_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["IngestionRun"]]]:
     """List Ingestion Runs For Ingestion Config
 
     Args:
         workspace_id (str):
         ingestion_config_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -169,5 +187,6 @@ async def asyncio(
             workspace_id=workspace_id,
             ingestion_config_id=ingestion_config_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/starters/get_latest_starters.py
+++ b/frontend/sdk/so_insights_client/api/starters/get_latest_starters.py
@@ -6,28 +6,35 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}/starters/",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List[str]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = cast(List[str], response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -52,11 +59,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List[str]]]:
     """Get Latest Starters
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -68,6 +77,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -81,11 +91,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List[str]]]:
     """Get Latest Starters
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -98,6 +110,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -105,11 +118,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List[str]]]:
     """Get Latest Starters
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -121,6 +136,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -132,11 +148,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List[str]]]:
     """Get Latest Starters
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -150,5 +168,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/workspaces/create_workspace.py
+++ b/frontend/sdk/so_insights_client/api/workspaces/create_workspace.py
@@ -8,14 +8,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.workspace import Workspace
 from ...models.workspace_create import WorkspaceCreate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: WorkspaceCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "post",
@@ -34,11 +37,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
-    if response.status_code == HTTPStatus.CREATED:
+    if response.status_code == 201:
         response_201 = Workspace.from_dict(response.json())
 
         return response_201
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -63,10 +66,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Create Workspace
 
     Args:
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceCreate):
 
     Raises:
@@ -79,6 +84,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -92,10 +98,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Create Workspace
 
     Args:
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceCreate):
 
     Raises:
@@ -109,6 +117,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -116,10 +125,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Create Workspace
 
     Args:
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceCreate):
 
     Raises:
@@ -132,6 +143,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -143,10 +155,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceCreate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Create Workspace
 
     Args:
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceCreate):
 
     Raises:
@@ -161,5 +175,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/workspaces/get_workspace.py
+++ b/frontend/sdk/so_insights_client/api/workspaces/get_workspace.py
@@ -7,28 +7,35 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.workspace import Workspace
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
+    *,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_id}",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = Workspace.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -53,11 +60,13 @@ def sync_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Get Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -69,6 +78,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -82,11 +92,13 @@ def sync(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Get Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -99,6 +111,7 @@ def sync(
     return sync_detailed(
         workspace_id=workspace_id,
         client=client,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -106,11 +119,13 @@ async def asyncio_detailed(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Get Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,6 +137,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -133,11 +149,13 @@ async def asyncio(
     workspace_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Get Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -151,5 +169,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_id=workspace_id,
             client=client,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/workspaces/list_workspaces.py
+++ b/frontend/sdk/so_insights_client/api/workspaces/list_workspaces.py
@@ -13,7 +13,12 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     *,
     enabled: Union[None, Unset, bool] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
+
     params: Dict[str, Any] = {}
 
     json_enabled: Union[None, Unset, bool]
@@ -31,13 +36,14 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, List["Workspace"]]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
         for response_200_item_data in _response_200:
@@ -46,7 +52,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -71,11 +77,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     enabled: Union[None, Unset, bool] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["Workspace"]]]:
     """List Workspaces
 
     Args:
         enabled (Union[None, Unset, bool]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,6 +95,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         enabled=enabled,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -100,11 +109,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     enabled: Union[None, Unset, bool] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["Workspace"]]]:
     """List Workspaces
 
     Args:
         enabled (Union[None, Unset, bool]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +128,7 @@ def sync(
     return sync_detailed(
         client=client,
         enabled=enabled,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -124,11 +136,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     enabled: Union[None, Unset, bool] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, List["Workspace"]]]:
     """List Workspaces
 
     Args:
         enabled (Union[None, Unset, bool]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -140,6 +154,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         enabled=enabled,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -151,11 +166,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     enabled: Union[None, Unset, bool] = UNSET,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, List["Workspace"]]]:
     """List Workspaces
 
     Args:
         enabled (Union[None, Unset, bool]):
+        x_organization_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -169,5 +186,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             enabled=enabled,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/api/workspaces/update_workspace.py
+++ b/frontend/sdk/so_insights_client/api/workspaces/update_workspace.py
@@ -8,15 +8,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.workspace import Workspace
 from ...models.workspace_update import WorkspaceUpdate
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_id: str,
     *,
     body: WorkspaceUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    if not isinstance(x_organization_id, Unset):
+        headers["x-organization-id"] = x_organization_id
 
     _kwargs: Dict[str, Any] = {
         "method": "put",
@@ -35,11 +38,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = Workspace.from_dict(response.json())
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+    if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
@@ -65,11 +68,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Update Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceUpdate):
 
     Raises:
@@ -83,6 +88,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,11 +103,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Update Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceUpdate):
 
     Raises:
@@ -116,6 +124,7 @@ def sync(
         workspace_id=workspace_id,
         client=client,
         body=body,
+        x_organization_id=x_organization_id,
     ).parsed
 
 
@@ -124,11 +133,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, Workspace]]:
     """Update Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceUpdate):
 
     Raises:
@@ -142,6 +153,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         workspace_id=workspace_id,
         body=body,
+        x_organization_id=x_organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,11 +166,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: WorkspaceUpdate,
+    x_organization_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, Workspace]]:
     """Update Workspace
 
     Args:
         workspace_id (str):
+        x_organization_id (Union[None, Unset, str]):
         body (WorkspaceUpdate):
 
     Raises:
@@ -174,5 +188,6 @@ async def asyncio(
             workspace_id=workspace_id,
             client=client,
             body=body,
+            x_organization_id=x_organization_id,
         )
     ).parsed

--- a/frontend/sdk/so_insights_client/client.py
+++ b/frontend/sdk/so_insights_client/client.py
@@ -70,7 +70,7 @@ class Client:
         return evolve(self, timeout=timeout)
 
     def set_httpx_client(self, client: httpx.Client) -> "Client":
-        """Manually the underlying httpx.Client
+        """Manually set the underlying httpx.Client
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """
@@ -204,7 +204,7 @@ class AuthenticatedClient:
         return evolve(self, timeout=timeout)
 
     def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
-        """Manually the underlying httpx.Client
+        """Manually set the underlying httpx.Client
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """

--- a/frontend/sdk/so_insights_client/models/organization.py
+++ b/frontend/sdk/so_insights_client/models/organization.py
@@ -32,6 +32,8 @@ class Organization:
             field_id (Union[None, Unset, str]): MongoDB document ObjectID
             created_at (Union[Unset, datetime.datetime]):
             updated_at (Union[Unset, datetime.datetime]):
+            content_analysis_enabled (Union[Unset, bool]): When enabled, the system will collect and analyze the articles
+                contents, not just title and metadata Default: False.
     """
 
     name: str
@@ -39,6 +41,7 @@ class Organization:
     field_id: Union[None, Unset, str] = UNSET
     created_at: Union[Unset, datetime.datetime] = UNSET
     updated_at: Union[Unset, datetime.datetime] = UNSET
+    content_analysis_enabled: Union[Unset, bool] = False
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -60,6 +63,8 @@ class Organization:
         if not isinstance(self.updated_at, Unset):
             updated_at = self.updated_at.isoformat()
 
+        content_analysis_enabled = self.content_analysis_enabled
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -74,6 +79,8 @@ class Organization:
             field_dict["created_at"] = created_at
         if updated_at is not UNSET:
             field_dict["updated_at"] = updated_at
+        if content_analysis_enabled is not UNSET:
+            field_dict["content_analysis_enabled"] = content_analysis_enabled
 
         return field_dict
 
@@ -107,12 +114,15 @@ class Organization:
         else:
             updated_at = isoparse(_updated_at)
 
+        content_analysis_enabled = d.pop("content_analysis_enabled", UNSET)
+
         organization = cls(
             name=name,
             secret_code=secret_code,
             field_id=field_id,
             created_at=created_at,
             updated_at=updated_at,
+            content_analysis_enabled=content_analysis_enabled,
         )
 
         organization.additional_properties = d

--- a/frontend/src/pages/chatbot.py
+++ b/frontend/src/pages/chatbot.py
@@ -197,7 +197,7 @@ def convert_docs(docs: Iterable[Document]) -> SetOfUniqueArticles:
 def format_docs(articles: SetOfUniqueArticles) -> str:
     separator = "\n\n---\n\n"
     return separator.join(
-        f"{article.title} - (Published on {article.date.strftime('%Y-%m-%d')})\n{article.url}\n{article.body}"
+        f"{article.title} - (Published on {article.date.strftime('%Y-%m-%d')})\n{article.url}\n{article.content if article.content else article.body}"
         for article in articles
     )
 

--- a/ingester/README.md
+++ b/ingester/README.md
@@ -8,6 +8,7 @@ The SO Insights Ingester collects, processes, and stores articles from various o
 
 - Asynchronous web searching using DuckDuckGo or Serper.dev
 - RSS feed ingestion
+- Fetching and cleaning of full article content using configurable providers (e.g. Firecrawl.dev)
 - Storage in MongoDB for structured data
 - Indexing in Pinecone for vector search capabilities
 - Command-line interface for various operations
@@ -20,6 +21,7 @@ The SO Insights Ingester collects, processes, and stores articles from various o
 - Pinecone account
 - VoyageAI API access
 - Serper.dev API key (if using Serper.dev as the search provider)
+- Firecrawl API Key
 
 ## Installation
 
@@ -37,6 +39,7 @@ poetry install
    PINECONE_API_KEY=your_pinecone_api_key
    PINECONE_INDEX=your_pinecone_index_name
    VOYAGEAI_API_KEY=your_voyageai_api_key
+   FIRECRAWL_API_KEY=your_firecrawl_api_key
    ```
 
 2. Adjust the settings in `src/ingester_settings.py` as needed.
@@ -73,6 +76,7 @@ The choice of search provider can be configured using the `SEARCH_PROVIDER` envi
 - Task Creation: Ingestion tasks are created based on configurations.
 - Web Search: Performs searches using DuckDuckGo API based on predefined queries.
 - RSS Feed Ingestion: Fetches and processes articles from RSS feeds.
+- Content Fetching and Cleaning: Fetches full article content from URLs using Firecrawl, and cleans it to remove irrelevant elements using gpt-4o-mini
 - Data Storage: Stores articles in MongoDB and indexes them in Pinecone.
 - Vector Synchronization: Ensures MongoDB and Pinecone are in sync.
 

--- a/ingester/main.py
+++ b/ingester/main.py
@@ -246,7 +246,10 @@ async def handle_ingestion_run(
                 )
                 assert len(to_fetch) == len(results)
                 for article, result in zip(to_fetch, results):
-                    article.content = result.cleaned_markdown
+                    article.content = (
+                        result.content_cleaner_output.cleaned_article_content
+                    )
+                    article.content_cleaning_error = result.content_cleaner_output.error
                     article.content_fetching_result = result
 
                 logger.info("Content fetching complete.")

--- a/ingester/poetry.lock
+++ b/ingester/poetry.lock
@@ -451,6 +451,24 @@ files = [
 sgmllib3k = "*"
 
 [[package]]
+name = "firecrawl-py"
+version = "1.10.0"
+description = "Python SDK for Firecrawl API"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "firecrawl_py-1.10.0-py3-none-any.whl", hash = "sha256:644aed8d34e01b00ef9c01f4d561c3c5efae49eb11e1af3b97eda176ed8c243e"},
+    {file = "firecrawl_py-1.10.0.tar.gz", hash = "sha256:ac504d82df1149df9640343e3f9c84ba2f0f9277149426ed641808dd8b56f921"},
+]
+
+[package.dependencies]
+nest-asyncio = "*"
+pydantic = ">=2.10.3"
+python-dotenv = "*"
+requests = "*"
+websockets = "*"
+
+[[package]]
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -941,6 +959,17 @@ files = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+description = "Patch asyncio to allow nested event loops"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
+    {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
+]
+
+[[package]]
 name = "numpy"
 version = "1.26.4"
 description = "Fundamental package for array computing in Python"
@@ -1147,19 +1176,19 @@ dev = ["certifi", "pytest (>=8.1.1)"]
 
 [[package]]
 name = "pydantic"
-version = "2.9.2"
+version = "2.10.5"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12"},
-    {file = "pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f"},
+    {file = "pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53"},
+    {file = "pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.23.4"
-typing-extensions = {version = ">=4.6.1", markers = "python_version < \"3.13\""}
+pydantic-core = "2.27.2"
+typing-extensions = ">=4.12.2"
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -1167,100 +1196,111 @@ timezone = ["tzdata"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.23.4"
+version = "2.27.2"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_core-2.23.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b10bd51f823d891193d4717448fab065733958bdb6a6b351967bd349d48d5c9b"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4fc714bdbfb534f94034efaa6eadd74e5b93c8fa6315565a222f7b6f42ca1166"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63e46b3169866bd62849936de036f901a9356e36376079b05efa83caeaa02ceb"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed1a53de42fbe34853ba90513cea21673481cd81ed1be739f7f2efb931b24916"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cfdd16ab5e59fc31b5e906d1a3f666571abc367598e3e02c83403acabc092e07"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255a8ef062cbf6674450e668482456abac99a5583bbafb73f9ad469540a3a232"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a7cd62e831afe623fbb7aabbb4fe583212115b3ef38a9f6b71869ba644624a2"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f09e2ff1f17c2b51f2bc76d1cc33da96298f0a036a137f5440ab3ec5360b624f"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e38e63e6f3d1cec5a27e0afe90a085af8b6806ee208b33030e65b6516353f1a3"},
-    {file = "pydantic_core-2.23.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0dbd8dbed2085ed23b5c04afa29d8fd2771674223135dc9bc937f3c09284d071"},
-    {file = "pydantic_core-2.23.4-cp310-none-win32.whl", hash = "sha256:6531b7ca5f951d663c339002e91aaebda765ec7d61b7d1e3991051906ddde119"},
-    {file = "pydantic_core-2.23.4-cp310-none-win_amd64.whl", hash = "sha256:7c9129eb40958b3d4500fa2467e6a83356b3b61bfff1b414c7361d9220f9ae8f"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0"},
-    {file = "pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64"},
-    {file = "pydantic_core-2.23.4-cp311-none-win32.whl", hash = "sha256:74b9127ffea03643e998e0c5ad9bd3811d3dac8c676e47db17b0ee7c3c3bf35f"},
-    {file = "pydantic_core-2.23.4-cp311-none-win_amd64.whl", hash = "sha256:98d134c954828488b153d88ba1f34e14259284f256180ce659e8d83e9c05eaa3"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e"},
-    {file = "pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24"},
-    {file = "pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84"},
-    {file = "pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6"},
-    {file = "pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f"},
-    {file = "pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769"},
-    {file = "pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d4488a93b071c04dc20f5cecc3631fc78b9789dd72483ba15d423b5b3689b555"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:81965a16b675b35e1d09dd14df53f190f9129c0202356ed44ab2728b1c905658"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffa2ebd4c8530079140dd2d7f794a9d9a73cbb8e9d59ffe24c63436efa8f271"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:61817945f2fe7d166e75fbfb28004034b48e44878177fc54d81688e7b85a3665"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29d2c342c4bc01b88402d60189f3df065fb0dda3654744d5a165a5288a657368"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5e11661ce0fd30a6790e8bcdf263b9ec5988e95e63cf901972107efc49218b13"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d18368b137c6295db49ce7218b1a9ba15c5bc254c96d7c9f9e924a9bc7825ad"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec4e55f79b1c4ffb2eecd8a0cfba9955a2588497d96851f4c8f99aa4a1d39b12"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:374a5e5049eda9e0a44c696c7ade3ff355f06b1fe0bb945ea3cac2bc336478a2"},
-    {file = "pydantic_core-2.23.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5c364564d17da23db1106787675fc7af45f2f7b58b4173bfdd105564e132e6fb"},
-    {file = "pydantic_core-2.23.4-cp38-none-win32.whl", hash = "sha256:d7a80d21d613eec45e3d41eb22f8f94ddc758a6c4720842dc74c0581f54993d6"},
-    {file = "pydantic_core-2.23.4-cp38-none-win_amd64.whl", hash = "sha256:5f5ff8d839f4566a474a969508fe1c5e59c31c80d9e140566f9a37bba7b8d556"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a4fa4fc04dff799089689f4fd502ce7d59de529fc2f40a2c8836886c03e0175a"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a7df63886be5e270da67e0966cf4afbae86069501d35c8c1b3b6c168f42cb36"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcedcd19a557e182628afa1d553c3895a9f825b936415d0dbd3cd0bbcfd29b4b"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f54b118ce5de9ac21c363d9b3caa6c800341e8c47a508787e5868c6b79c9323"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86d2f57d3e1379a9525c5ab067b27dbb8a0642fb5d454e17a9ac434f9ce523e3"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de6d1d1b9e5101508cb37ab0d972357cac5235f5c6533d1071964c47139257df"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1278e0d324f6908e872730c9102b0112477a7f7cf88b308e4fc36ce1bdb6d58c"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a6b5099eeec78827553827f4c6b8615978bb4b6a88e5d9b93eddf8bb6790f55"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e55541f756f9b3ee346b840103f32779c695a19826a4c442b7954550a0972040"},
-    {file = "pydantic_core-2.23.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a5c7ba8ffb6d6f8f2ab08743be203654bb1aaa8c9dcb09f82ddd34eadb695605"},
-    {file = "pydantic_core-2.23.4-cp39-none-win32.whl", hash = "sha256:37b0fe330e4a58d3c58b24d91d1eb102aeec675a3db4c292ec3928ecd892a9a6"},
-    {file = "pydantic_core-2.23.4-cp39-none-win_amd64.whl", hash = "sha256:1498bec4c05c9c787bde9125cfdcc63a41004ff167f495063191b863399b1a29"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f455ee30a9d61d3e1a15abd5068827773d6e4dc513e795f380cdd59932c782d5"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1e90d2e3bd2c3863d48525d297cd143fe541be8bbf6f579504b9712cb6b643ec"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e203fdf807ac7e12ab59ca2bfcabb38c7cf0b33c41efeb00f8e5da1d86af480"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e08277a400de01bc72436a0ccd02bdf596631411f592ad985dcee21445bd0068"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f220b0eea5965dec25480b6333c788fb72ce5f9129e8759ef876a1d805d00801"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d06b0c8da4f16d1d1e352134427cb194a0a6e19ad5db9161bf32b2113409e728"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:ba1a0996f6c2773bd83e63f18914c1de3c9dd26d55f4ac302a7efe93fb8e7433"},
-    {file = "pydantic_core-2.23.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:9a5bce9d23aac8f0cf0836ecfc033896aa8443b501c58d0602dbfd5bd5b37753"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:78ddaaa81421a29574a682b3179d4cf9e6d405a09b99d93ddcf7e5239c742e21"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:883a91b5dd7d26492ff2f04f40fbb652de40fcc0afe07e8129e8ae779c2110eb"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88ad334a15b32a791ea935af224b9de1bf99bcd62fabf745d5f3442199d86d59"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:233710f069d251feb12a56da21e14cca67994eab08362207785cf8c598e74577"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:19442362866a753485ba5e4be408964644dd6a09123d9416c54cd49171f50744"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:624e278a7d29b6445e4e813af92af37820fafb6dcc55c012c834f9e26f9aaaef"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f5ef8f42bec47f21d07668a043f077d507e5bf4e668d5c6dfe6aaba89de1a5b8"},
-    {file = "pydantic_core-2.23.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:aea443fffa9fbe3af1a9ba721a87f926fe548d32cab71d188a6ede77d0ff244e"},
-    {file = "pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4"},
+    {file = "pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc"},
+    {file = "pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9"},
+    {file = "pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee"},
+    {file = "pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d3e8d504bdd3f10835468f29008d72fc8359d95c9c415ce6e767203db6127506"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:521eb9b7f036c9b6187f0b47318ab0d7ca14bd87f776240b90b21c1f4f149320"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85210c4d99a0114f5a9481b44560d7d1e35e32cc5634c656bc48e590b669b145"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d716e2e30c6f140d7560ef1538953a5cd1a87264c737643d481f2779fc247fe1"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f66d89ba397d92f840f8654756196d93804278457b5fbede59598a1f9f90b228"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:669e193c1c576a58f132e3158f9dfa9662969edb1a250c54d8fa52590045f046"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdbe7629b996647b99c01b37f11170a57ae675375b14b8c13b8518b8320ced5"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d262606bf386a5ba0b0af3b97f37c83d7011439e3dc1a9298f21efb292e42f1a"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cabb9bcb7e0d97f74df8646f34fc76fbf793b7f6dc2438517d7a9e50eee4f14d"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:d2d63f1215638d28221f664596b1ccb3944f6e25dd18cd3b86b0a4c408d5ebb9"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bca101c00bff0adb45a833f8451b9105d9df18accb8743b08107d7ada14bd7da"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-win32.whl", hash = "sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b"},
+    {file = "pydantic_core-2.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c10eb4f1659290b523af58fa7cffb452a61ad6ae5613404519aee4bfbf1df993"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef592d4bad47296fb11f96cd7dc898b92e795032b4894dfb4076cfccd43a9308"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61709a844acc6bf0b7dce7daae75195a10aac96a596ea1b776996414791ede4"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c5f762659e47fdb7b16956c71598292f60a03aa92f8b6351504359dbdba6cf"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c9775e339e42e79ec99c441d9730fccf07414af63eac2f0e48e08fd38a64d76"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57762139821c31847cfb2df63c12f725788bd9f04bc2fb392790959b8f70f118"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1e85068e818c73e048fe28cfc769040bb1f475524f4745a5dc621f75ac7630"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:097830ed52fd9e427942ff3b9bc17fab52913b2f50f2880dc4a5611446606a54"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044a50963a614ecfae59bb1eaf7ea7efc4bc62f49ed594e18fa1e5d953c40e9f"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:4e0b4220ba5b40d727c7f879eac379b822eee5d8fff418e9d3381ee45b3b0362"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e4f4bb20d75e9325cc9696c6802657b58bc1dbbe3022f32cc2b2b632c3fbb96"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-win32.whl", hash = "sha256:cca63613e90d001b9f2f9a9ceb276c308bfa2a43fafb75c8031c4f66039e8c6e"},
+    {file = "pydantic_core-2.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:77d1bca19b0f7021b3a982e6f903dcd5b2b06076def36a652e3907f596e29f67"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9"},
+    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c33939a82924da9ed65dab5a65d427205a73181d8098e79b6b426bdf8ad4e656"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817e2b40aba42bac6f457498dacabc568c3b7a986fc9ba7c8d9d260b71485fb"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:251136cdad0cb722e93732cb45ca5299fb56e1344a833640bf93b2803f8d1bfd"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2088237af596f0a524d3afc39ab3b036e8adb054ee57cbb1dcf8e09da5b29cc"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4041c0b966a84b4ae7a09832eb691a35aec90910cd2dbe7a208de59be77965b"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8083d4e875ebe0b864ffef72a4304827015cff328a1be6e22cc850753bfb122b"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f141ee28a0ad2123b6611b6ceff018039df17f32ada8b534e6aa039545a3efb2"},
+    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7d0c8399fcc1848491f00e0314bd59fb34a9c008761bcb422a057670c3f65e35"},
+    {file = "pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39"},
 ]
 
 [package.dependencies]
@@ -1933,6 +1973,84 @@ requests = ">=2.20,<3.0"
 tenacity = ">=8.0.1"
 
 [[package]]
+name = "websockets"
+version = "14.2"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "websockets-14.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e8179f95323b9ab1c11723e5d91a89403903f7b001828161b480a7810b334885"},
+    {file = "websockets-14.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0d8c3e2cdb38f31d8bd7d9d28908005f6fa9def3324edb9bf336d7e4266fd397"},
+    {file = "websockets-14.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:714a9b682deb4339d39ffa674f7b674230227d981a37d5d174a4a83e3978a610"},
+    {file = "websockets-14.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2e53c72052f2596fb792a7acd9704cbc549bf70fcde8a99e899311455974ca3"},
+    {file = "websockets-14.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3fbd68850c837e57373d95c8fe352203a512b6e49eaae4c2f4088ef8cf21980"},
+    {file = "websockets-14.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b27ece32f63150c268593d5fdb82819584831a83a3f5809b7521df0685cd5d8"},
+    {file = "websockets-14.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4daa0faea5424d8713142b33825fff03c736f781690d90652d2c8b053345b0e7"},
+    {file = "websockets-14.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:bc63cee8596a6ec84d9753fd0fcfa0452ee12f317afe4beae6b157f0070c6c7f"},
+    {file = "websockets-14.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7a570862c325af2111343cc9b0257b7119b904823c675b22d4ac547163088d0d"},
+    {file = "websockets-14.2-cp310-cp310-win32.whl", hash = "sha256:75862126b3d2d505e895893e3deac0a9339ce750bd27b4ba515f008b5acf832d"},
+    {file = "websockets-14.2-cp310-cp310-win_amd64.whl", hash = "sha256:cc45afb9c9b2dc0852d5c8b5321759cf825f82a31bfaf506b65bf4668c96f8b2"},
+    {file = "websockets-14.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3bdc8c692c866ce5fefcaf07d2b55c91d6922ac397e031ef9b774e5b9ea42166"},
+    {file = "websockets-14.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c93215fac5dadc63e51bcc6dceca72e72267c11def401d6668622b47675b097f"},
+    {file = "websockets-14.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c9b6535c0e2cf8a6bf938064fb754aaceb1e6a4a51a80d884cd5db569886910"},
+    {file = "websockets-14.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a52a6d7cf6938e04e9dceb949d35fbdf58ac14deea26e685ab6368e73744e4c"},
+    {file = "websockets-14.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9f05702e93203a6ff5226e21d9b40c037761b2cfb637187c9802c10f58e40473"},
+    {file = "websockets-14.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22441c81a6748a53bfcb98951d58d1af0661ab47a536af08920d129b4d1c3473"},
+    {file = "websockets-14.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:efd9b868d78b194790e6236d9cbc46d68aba4b75b22497eb4ab64fa640c3af56"},
+    {file = "websockets-14.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1a5a20d5843886d34ff8c57424cc65a1deda4375729cbca4cb6b3353f3ce4142"},
+    {file = "websockets-14.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:34277a29f5303d54ec6468fb525d99c99938607bc96b8d72d675dee2b9f5bf1d"},
+    {file = "websockets-14.2-cp311-cp311-win32.whl", hash = "sha256:02687db35dbc7d25fd541a602b5f8e451a238ffa033030b172ff86a93cb5dc2a"},
+    {file = "websockets-14.2-cp311-cp311-win_amd64.whl", hash = "sha256:862e9967b46c07d4dcd2532e9e8e3c2825e004ffbf91a5ef9dde519ee2effb0b"},
+    {file = "websockets-14.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f20522e624d7ffbdbe259c6b6a65d73c895045f76a93719aa10cd93b3de100c"},
+    {file = "websockets-14.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:647b573f7d3ada919fd60e64d533409a79dcf1ea21daeb4542d1d996519ca967"},
+    {file = "websockets-14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6af99a38e49f66be5a64b1e890208ad026cda49355661549c507152113049990"},
+    {file = "websockets-14.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:091ab63dfc8cea748cc22c1db2814eadb77ccbf82829bac6b2fbe3401d548eda"},
+    {file = "websockets-14.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b374e8953ad477d17e4851cdc66d83fdc2db88d9e73abf755c94510ebddceb95"},
+    {file = "websockets-14.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a39d7eceeea35db85b85e1169011bb4321c32e673920ae9c1b6e0978590012a3"},
+    {file = "websockets-14.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0a6f3efd47ffd0d12080594f434faf1cd2549b31e54870b8470b28cc1d3817d9"},
+    {file = "websockets-14.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:065ce275e7c4ffb42cb738dd6b20726ac26ac9ad0a2a48e33ca632351a737267"},
+    {file = "websockets-14.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e9d0e53530ba7b8b5e389c02282f9d2aa47581514bd6049d3a7cffe1385cf5fe"},
+    {file = "websockets-14.2-cp312-cp312-win32.whl", hash = "sha256:20e6dd0984d7ca3037afcb4494e48c74ffb51e8013cac71cf607fffe11df7205"},
+    {file = "websockets-14.2-cp312-cp312-win_amd64.whl", hash = "sha256:44bba1a956c2c9d268bdcdf234d5e5ff4c9b6dc3e300545cbe99af59dda9dcce"},
+    {file = "websockets-14.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6f1372e511c7409a542291bce92d6c83320e02c9cf392223272287ce55bc224e"},
+    {file = "websockets-14.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4da98b72009836179bb596a92297b1a61bb5a830c0e483a7d0766d45070a08ad"},
+    {file = "websockets-14.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8a86a269759026d2bde227652b87be79f8a734e582debf64c9d302faa1e9f03"},
+    {file = "websockets-14.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86cf1aaeca909bf6815ea714d5c5736c8d6dd3a13770e885aafe062ecbd04f1f"},
+    {file = "websockets-14.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b0f6c3ba3b1240f602ebb3971d45b02cc12bd1845466dd783496b3b05783a5"},
+    {file = "websockets-14.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:669c3e101c246aa85bc8534e495952e2ca208bd87994650b90a23d745902db9a"},
+    {file = "websockets-14.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eabdb28b972f3729348e632ab08f2a7b616c7e53d5414c12108c29972e655b20"},
+    {file = "websockets-14.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2066dc4cbcc19f32c12a5a0e8cc1b7ac734e5b64ac0a325ff8353451c4b15ef2"},
+    {file = "websockets-14.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab95d357cd471df61873dadf66dd05dd4709cae001dd6342edafc8dc6382f307"},
+    {file = "websockets-14.2-cp313-cp313-win32.whl", hash = "sha256:a9e72fb63e5f3feacdcf5b4ff53199ec8c18d66e325c34ee4c551ca748623bbc"},
+    {file = "websockets-14.2-cp313-cp313-win_amd64.whl", hash = "sha256:b439ea828c4ba99bb3176dc8d9b933392a2413c0f6b149fdcba48393f573377f"},
+    {file = "websockets-14.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7cd5706caec1686c5d233bc76243ff64b1c0dc445339bd538f30547e787c11fe"},
+    {file = "websockets-14.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ec607328ce95a2f12b595f7ae4c5d71bf502212bddcea528290b35c286932b12"},
+    {file = "websockets-14.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:da85651270c6bfb630136423037dd4975199e5d4114cae6d3066641adcc9d1c7"},
+    {file = "websockets-14.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ecadc7ce90accf39903815697917643f5b7cfb73c96702318a096c00aa71f5"},
+    {file = "websockets-14.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1979bee04af6a78608024bad6dfcc0cc930ce819f9e10342a29a05b5320355d0"},
+    {file = "websockets-14.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dddacad58e2614a24938a50b85969d56f88e620e3f897b7d80ac0d8a5800258"},
+    {file = "websockets-14.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:89a71173caaf75fa71a09a5f614f450ba3ec84ad9fca47cb2422a860676716f0"},
+    {file = "websockets-14.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6af6a4b26eea4fc06c6818a6b962a952441e0e39548b44773502761ded8cc1d4"},
+    {file = "websockets-14.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:80c8efa38957f20bba0117b48737993643204645e9ec45512579132508477cfc"},
+    {file = "websockets-14.2-cp39-cp39-win32.whl", hash = "sha256:2e20c5f517e2163d76e2729104abc42639c41cf91f7b1839295be43302713661"},
+    {file = "websockets-14.2-cp39-cp39-win_amd64.whl", hash = "sha256:b4c8cef610e8d7c70dea92e62b6814a8cd24fbd01d7103cc89308d2bfe1659ef"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d7d9cafbccba46e768be8a8ad4635fa3eae1ffac4c6e7cb4eb276ba41297ed29"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c76193c1c044bd1e9b3316dcc34b174bbf9664598791e6fb606d8d29000e070c"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd475a974d5352390baf865309fe37dec6831aafc3014ffac1eea99e84e83fc2"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c6c0097a41968b2e2b54ed3424739aab0b762ca92af2379f152c1aef0187e1c"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d7ff794c8b36bc402f2e07c0b2ceb4a2424147ed4785ff03e2a7af03711d60a"},
+    {file = "websockets-14.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:dec254fcabc7bd488dab64846f588fc5b6fe0d78f641180030f8ea27b76d72c3"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:bbe03eb853e17fd5b15448328b4ec7fb2407d45fb0245036d06a3af251f8e48f"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a3c4aa3428b904d5404a0ed85f3644d37e2cb25996b7f096d77caeb0e96a3b42"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:577a4cebf1ceaf0b65ffc42c54856214165fb8ceeba3935852fc33f6b0c55e7f"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad1c1d02357b7665e700eca43a31d52814ad9ad9b89b58118bdabc365454b574"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f390024a47d904613577df83ba700bd189eedc09c57af0a904e5c39624621270"},
+    {file = "websockets-14.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3c1426c021c38cf92b453cdf371228d3430acd775edee6bac5a4d577efc72365"},
+    {file = "websockets-14.2-py3-none-any.whl", hash = "sha256:7a6ceec4ea84469f15cf15807a747e9efe57e369c384fa86e022b3bea679b79b"},
+    {file = "websockets-14.2.tar.gz", hash = "sha256:5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.11.1"
 description = "Yet another URL library"
@@ -2040,4 +2158,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "353f064344986c47c592d1c5b3b4d14e07dec6783291eeb10db61db0e9f0e415"
+content-hash = "311b79f29eaff41b896f30e3500e65b720d505956cff61e6651191baf7dbfe0d"

--- a/ingester/pyproject.toml
+++ b/ingester/pyproject.toml
@@ -23,6 +23,7 @@ fastapi = "^0.113.0"
 uvicorn = "^0.30.6"
 feedparser = "^6.0.11"
 dateparser = "^1.2.0"
+firecrawl-py = "^1.10.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/ingester/src/content_cleaner.py
+++ b/ingester/src/content_cleaner.py
@@ -1,0 +1,82 @@
+import logging
+
+from langchain import hub
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import Runnable
+
+from shared.content_fetching_models import ArticleContentCleanerOutput
+from src.ingester_settings import ingester_settings
+
+logger = logging.getLogger(__name__)
+
+
+ArticleContentCleanerChain = Runnable[str, ArticleContentCleanerOutput]
+
+
+class ArticleContentCleaner:
+    """
+    Cleans the markdown content of an article using an LLM.
+    """
+
+    def __init__(self, llm: BaseChatModel | None = None):
+        self.llm = llm or init_chat_model(ingester_settings.CONTENT_CLEANER_MODEL)
+        self.chain = self._create_chain()
+
+    @classmethod
+    def _parse_output(cls, output: str) -> ArticleContentCleanerOutput:
+        """
+        Parses the output of the article content cleaner LLM.
+
+        Assuming the LLM output format is:
+
+        ```md
+        # Article title
+
+        <cleaned markdown article content>
+        ```
+        """
+
+        lines = output.split("\n")
+        title = lines[0].strip("# ")
+        cleaned_markdown = "\n".join(lines[1:]).strip()
+
+        return ArticleContentCleanerOutput(
+            title=title, cleaned_markdown=cleaned_markdown
+        )
+
+    def _create_chain(self) -> ArticleContentCleanerChain:
+        """
+        Creates the LangChain chain for article content cleaning.
+        """
+        prompt = hub.pull(ingester_settings.ARTICLE_CONTENT_CLEANER_PROMPT_REF)
+
+        return (prompt | self.llm | StrOutputParser() | self._parse_output).with_config(
+            run_name="article_content_cleaner_chain"
+        )
+
+    def get_chain(self) -> ArticleContentCleanerChain:
+        """
+        Returns the LangChain chain for article content cleaning.
+        """
+        return self.chain
+
+    async def clean_article_content(
+        self, raw_markdown_content: str, metadata: dict = {}
+    ) -> ArticleContentCleanerOutput:
+        """
+        Cleans the markdown content of an article.
+
+        Args:
+            markdown (str): The markdown content to clean.
+
+        Returns:
+            ArticleContentCleanerOutput: The cleaned markdown content.
+        """
+
+        logger.info("Cleaning article content...")
+
+        return await self.chain.ainvoke(
+            raw_markdown_content, config={"metadata": metadata}
+        )

--- a/ingester/src/content_cleaner.py
+++ b/ingester/src/content_cleaner.py
@@ -3,7 +3,6 @@ import logging
 from langchain import hub
 from langchain.chat_models import init_chat_model
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables import Runnable
 
 from shared.content_fetching_models import ArticleContentCleanerOutput

--- a/ingester/src/content_fetcher.py
+++ b/ingester/src/content_fetcher.py
@@ -37,7 +37,6 @@ class ContentFetcher:
         return ContentFetchingResult(
             url=url,
             url_to_markdown_conversion=url_to_markdown,
-            cleaned_markdown=cleaned_markdown.cleaned_markdown,
             content_cleaner_output=cleaned_markdown,
         )
 

--- a/ingester/src/content_fetcher.py
+++ b/ingester/src/content_fetcher.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+
+from pydantic import HttpUrl
+
+from shared.content_fetching_models import ContentFetchingResult
+from src.content_cleaner import ArticleContentCleaner
+from src.url_to_markdown_converters.base import (
+    UrlToMarkdownConverter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ContentFetcher:
+    def __init__(
+        self,
+        url_to_markdown_converter: UrlToMarkdownConverter,
+        cleaner: ArticleContentCleaner,
+    ):
+        self.url_to_markdown_converter = url_to_markdown_converter
+        self.cleaner = cleaner
+
+    async def convert_and_clean(self, url: HttpUrl) -> ContentFetchingResult:
+        logger.info(f"Converting and cleaning content from URL: {url}")
+
+        url_to_markdown = await self.url_to_markdown_converter.convert_url(url)
+
+        cleaned_markdown = await self.cleaner.clean_article_content(
+            url_to_markdown.markdown,
+            metadata={
+                "url": str(url),
+                "extraction_method": url_to_markdown.extraction_method,
+            },
+        )
+
+        return ContentFetchingResult(
+            url=url,
+            url_to_markdown_conversion=url_to_markdown,
+            cleaned_markdown=cleaned_markdown.cleaned_markdown,
+            content_cleaner_output=cleaned_markdown,
+        )
+
+    async def abatch_convert_and_clean(
+        self, urls: list[HttpUrl]
+    ) -> list[ContentFetchingResult]:
+        logger.info(f"Converting and cleaning {len(urls)} URLs")
+
+        return await asyncio.gather(*[self.convert_and_clean(url) for url in urls])

--- a/ingester/src/ingester_settings.py
+++ b/ingester/src/ingester_settings.py
@@ -44,6 +44,13 @@ class IngesterSettings(BaseSettings):
     MAX_RUNTIME_S: int = 30 * 60  # 30 minutes
     PORT: int = 8081
 
+    # Content Cleaner settings
+    CONTENT_CLEANER_MODEL: str = "gpt-4o-mini"
+    ARTICLE_CONTENT_CLEANER_PROMPT_REF: str = (
+        "clean-article-content"  # Reference to Langsmith Hub
+    )
+    FIRECRAWL_API_KEY: SecretStr = Field(default=...)
+
 
 ingester_settings = IngesterSettings()
 

--- a/ingester/src/rss.py
+++ b/ingester/src/rss.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import logging
-from typing import List, Dict, Any
+from typing import Any
 
 import aiohttp
 import feedparser
@@ -27,7 +27,7 @@ async def _fetch_rss_feed(session: aiohttp.ClientSession, url: str) -> str:
         return await response.text()
 
 
-async def _parse_rss_feed(feed_content: str) -> List[Dict[str, Any]]:
+async def _parse_rss_feed(feed_content: str) -> list[dict[str, Any]]:
     """
     Parses the content of an RSS feed.
 
@@ -62,7 +62,7 @@ def _entry_to_published_date(published_parsed) -> datetime | None:
 
 
 def _convert_to_article(
-    entry: Dict[str, Any],
+    entry: dict[str, Any],
     workspace_id: PydanticObjectId,
     ingestion_run_id: PydanticObjectId,
 ) -> Article:

--- a/ingester/src/url_to_markdown_converters/__init__.py
+++ b/ingester/src/url_to_markdown_converters/__init__.py
@@ -1,0 +1,13 @@
+from .base import (
+    UrlToMarkdownConverter,
+    UrlToMarkdownConversionError,
+    UrlToMarkdownConversion,
+)
+from .firecrawl_url_to_markdown_converter import FirecrawlUrlToMarkdown
+
+__all__ = [
+    "UrlToMarkdownConverter",
+    "UrlToMarkdownConversionError",
+    "FirecrawlUrlToMarkdown",
+    "UrlToMarkdownConversion",
+]

--- a/ingester/src/url_to_markdown_converters/base.py
+++ b/ingester/src/url_to_markdown_converters/base.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+
+from pydantic import HttpUrl
+from shared.content_fetching_models import UrlToMarkdownConversion
+
+
+class UrlToMarkdownConversionError(Exception):
+    """Custom exception raised for errors during URL to Markdown conversion."""
+
+    pass
+
+
+class UrlToMarkdownConverter(ABC):
+    """
+    Abstract base class for converting the content of a URL to Markdown.
+
+    This interface defines the contract for any class that provides
+    functionality to fetch and convert web page content into Markdown format.
+    """
+
+    @property
+    @abstractmethod
+    def extraction_method(self) -> str:
+        """The name of the extraction method used by this converter"""
+        pass
+
+    @abstractmethod
+    async def convert_url(self, url: HttpUrl) -> UrlToMarkdownConversion:
+        """
+        Converts the content of the given URL to Markdown.
+
+        Args:
+            url: The URL of the web page to convert.
+
+        Returns:
+            A `UrlToMarkdownConversion` object containing the URL, the converted
+            Markdown content, and the timestamp when the content was extracted.
+        """
+        pass
+
+    @abstractmethod
+    async def convert_urls(self, urls: list[HttpUrl]) -> list[UrlToMarkdownConversion]:
+        """
+        Converts the content of the given URLs to Markdown.
+
+        Args:
+            urls: A list of URLs to convert.
+
+        Returns:
+            A list of `UrlToMarkdownConversion` objects containing the URLs, the converted
+            Markdown content, and the timestamp when the content was extracted.
+        """
+        pass

--- a/ingester/src/url_to_markdown_converters/firecrawl_url_to_markdown_converter.py
+++ b/ingester/src/url_to_markdown_converters/firecrawl_url_to_markdown_converter.py
@@ -1,0 +1,127 @@
+import asyncio
+import logging
+
+from aiolimiter import AsyncLimiter
+from firecrawl import FirecrawlApp  # Assuming this is the correct import from the SDK
+from pydantic import HttpUrl, SecretStr
+from requests import HTTPError
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from . import (
+    UrlToMarkdownConversion,
+    UrlToMarkdownConversionError,
+    UrlToMarkdownConverter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FirecrawlUrlToMarkdown(UrlToMarkdownConverter):
+    """
+    Converts the content of a given URL to Markdown using the Firecrawl API.
+    """
+
+    def __init__(self, api_key: SecretStr | str | None = None):
+        if api_key is None:
+            self.app = FirecrawlApp()
+        else:
+            api_key = (
+                api_key.get_secret_value()
+                if isinstance(api_key, SecretStr)
+                else api_key
+            )
+            self.app = FirecrawlApp(api_key=api_key)
+
+        # allow for 10 concurrent entries within a 60 second window
+        self._rate_limiter = AsyncLimiter(max_rate=8, time_period=60)
+
+    @property
+    def extraction_method(self) -> str:
+        return "firecrawl"
+
+    async def convert_url(self, url: HttpUrl) -> UrlToMarkdownConversion:
+        """
+        Converts the content of the given URL to Markdown using the Firecrawl API.
+        Rate limited to avoid overwhelming the API.
+
+        Args:
+            url: The URL of the web page to convert.
+
+        Returns: UrlToMarkdownConversion
+
+        """
+
+        async with self._rate_limiter:
+            return await self._convert_url(url)
+
+    @retry(
+        stop=stop_after_attempt(10),
+        wait=wait_exponential(multiplier=3, min=4, max=60),
+        retry=retry_if_exception_type((HTTPError)),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        # If all retries fail get the original error (HTTPError)
+        retry_error_callback=lambda retry_state: retry_state.outcome.result(),  # type: ignore
+    )
+    async def _convert_url(self, url: HttpUrl) -> UrlToMarkdownConversion:
+        logger.info(f"Converting URL to Markdown using Firecrawl API: {url}")
+        try:
+            scrape_result = self.app.scrape_url(
+                str(url), params={"formats": ["markdown"]}
+            )
+
+            if not scrape_result or not isinstance(scrape_result, dict):
+                raise UrlToMarkdownConversionError(
+                    f"Unexpected response type from Firecrawl API: {type(scrape_result)}"
+                )
+
+            markdown_content = scrape_result.get("markdown")
+
+            if not markdown_content:
+                raise UrlToMarkdownConversionError(
+                    f"Markdown content not found in Firecrawl API response for URL: {url}"
+                )
+
+            if metadata := scrape_result.get("metadata", {}):
+                if not isinstance(metadata, dict):
+                    raise UrlToMarkdownConversionError(
+                        f"Metadata must be a dictionary, got {type(metadata)}"
+                    )
+
+            return UrlToMarkdownConversion(
+                url=url,
+                markdown=markdown_content,
+                metadata=metadata,
+                extraction_method=self.extraction_method,
+            )
+        except HTTPError as e:
+            # Retry on:
+            # - 429: Rate limit exceeded, need to wait before retrying
+            # - 408: Request timeout, temporary network/server issue
+            if e.response.status_code in (429, 408):
+                raise  # Will trigger retry
+            raise UrlToMarkdownConversionError(
+                f"Error converting URL to Markdown using Firecrawl API: {e}"
+            ) from e
+
+        except Exception as e:
+            raise UrlToMarkdownConversionError(
+                f"Error converting URL to Markdown using Firecrawl API: {e}"
+            ) from e
+
+    async def convert_urls(self, urls: list[HttpUrl]) -> list[UrlToMarkdownConversion]:
+        """
+        Converts the content of the given URLs to Markdown using the Firecrawl API.
+        Rate limited to avoid overwhelming the API.
+
+        Args:
+            urls: The URLs of the web pages to convert.
+
+        Returns: list[UrlToMarkdownConversion]
+        """
+        return await asyncio.gather(*[self.convert_url(url) for url in urls])

--- a/shared/shared/content_fetching_models.py
+++ b/shared/shared/content_fetching_models.py
@@ -20,8 +20,11 @@ class UrlToMarkdownConversion(BaseModel):
 class ArticleContentCleanerOutput(BaseModel):
     """Output for the article content cleaner."""
 
-    title: str = Field(..., description="Title of the article")
-    cleaned_markdown: str = Field(..., description="Cleaned markdown content")
+    error: str | None = Field(
+        None, description="Error message if the content could not be cleaned."
+    )
+    title: str | None = Field(..., description="Title of the article")
+    cleaned_markdown: str | None = Field(..., description="Cleaned markdown content")
 
 
 class ContentFetchingResult(BaseModel):

--- a/shared/shared/content_fetching_models.py
+++ b/shared/shared/content_fetching_models.py
@@ -1,5 +1,5 @@
 from typing import Any
-from pydantic import BaseModel, Field, HttpUrl, PastDatetime
+from pydantic import BaseModel, Field, HttpUrl, PastDatetime, field_validator
 from shared.util import utc_datetime_factory
 
 
@@ -21,10 +21,18 @@ class ArticleContentCleanerOutput(BaseModel):
     """Output for the article content cleaner."""
 
     error: str | None = Field(
-        None, description="Error message if the content could not be cleaned."
+        default=None, description="Error message if the content could not be cleaned."
     )
-    title: str | None = Field(..., description="Title of the article")
-    cleaned_markdown: str | None = Field(..., description="Cleaned markdown content")
+    title: str | None = Field(default=None, description="Title of the article")
+    cleaned_article_content: str | None = Field(
+        default=None, description="Cleaned article content in markdown format"
+    )
+
+    @field_validator("error")
+    def empty_string_to_none(cls, v: str | None) -> str | None:
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
 
 
 class ContentFetchingResult(BaseModel):
@@ -33,6 +41,5 @@ class ContentFetchingResult(BaseModel):
     """
 
     url: HttpUrl = Field(..., description="The URL of the content")
-    cleaned_markdown: str = Field(..., description="The cleaned markdown content")
     url_to_markdown_conversion: UrlToMarkdownConversion
     content_cleaner_output: ArticleContentCleanerOutput

--- a/shared/shared/content_fetching_models.py
+++ b/shared/shared/content_fetching_models.py
@@ -1,0 +1,35 @@
+from typing import Any
+from pydantic import BaseModel, Field, HttpUrl, PastDatetime
+from shared.util import utc_datetime_factory
+
+
+class UrlToMarkdownConversion(BaseModel):
+    """
+    Represents the result of converting a URL to Markdown.
+    """
+
+    url: HttpUrl
+    markdown: str
+    extracted_at: PastDatetime = Field(default_factory=utc_datetime_factory)
+    extraction_method: str = Field(..., description="e.g Firecrawl, Jina...")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Metadata returned by the extraction method"
+    )
+
+
+class ArticleContentCleanerOutput(BaseModel):
+    """Output for the article content cleaner."""
+
+    title: str = Field(..., description="Title of the article")
+    cleaned_markdown: str = Field(..., description="Cleaned markdown content")
+
+
+class ContentFetchingResult(BaseModel):
+    """
+    Represents the result of fetching and cleaning content from a URL.
+    """
+
+    url: HttpUrl = Field(..., description="The URL of the content")
+    cleaned_markdown: str = Field(..., description="The cleaned markdown content")
+    url_to_markdown_conversion: UrlToMarkdownConversion
+    content_cleaner_output: ArticleContentCleanerOutput

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -378,6 +378,10 @@ class Article(Document):
         Field(default="", description="Source of the article")
     )
     content: str | None = Field(default=None, description="Full content of the article")
+    content_cleaning_error: str | None = Field(
+        default=None, description="Error message if the content could not be cleaned"
+    )
+
     ingestion_run_id: PydanticObjectId | None = Field(
         None, description="ID of the ingestion run that found this article"
     )

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -88,6 +88,11 @@ class Organization(Document):
     created_at: datetime = Field(default_factory=utc_datetime_factory)
     updated_at: datetime = Field(default_factory=utc_datetime_factory)
 
+    content_analysis_enabled: bool = Field(
+        default=False,
+        description="When enabled, the system will collect and analyze the articles contents, not just title and metadata",
+    )
+
     class Settings:
         name = db_settings.mongodb_organizations_collection
         indexes = [

--- a/shared/shared/models.py
+++ b/shared/shared/models.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Dict, Literal, Self
 
@@ -16,14 +16,11 @@ from pydantic import (
 )
 from pymongo import IndexModel
 
+from shared.content_fetching_models import ContentFetchingResult
 from shared.db_settings import db_settings
 from shared.language import Language
 from shared.region import Region
-
-
-# TODO auto change update_at like in https://github.com/naoTimesdev/showtimes/blob/79ed15aa647c6fb8ee9a1f694b54d90a5ed7dda0/showtimes/models/database.py#L24
-def utc_datetime_factory():
-    return datetime.now(UTC)
+from shared.util import utc_datetime_factory
 
 
 type SearchProvider = Literal["duckduckgo", "serperdev", "rss"]
@@ -391,6 +388,11 @@ class Article(Document):
 
     provider: SearchProvider = Field(
         ..., description="The provider that found the article"
+    )
+
+    content_fetching_result: ContentFetchingResult | None = Field(
+        default=None,
+        description="The result of fetching and cleaning the article content",
     )
 
     @field_validator("title", mode="before")

--- a/shared/shared/util.py
+++ b/shared/shared/util.py
@@ -1,5 +1,11 @@
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 from pydantic_core import Url
+
+
+# TODO auto change update_at like in https://github.com/naoTimesdev/showtimes/blob/79ed15aa647c6fb8ee9a1f694b54d90a5ed7dda0/showtimes/models/database.py#L24
+def utc_datetime_factory():
+    return datetime.now(UTC)
 
 
 def validate_url(url: str | Url | None) -> str | None:


### PR DESCRIPTION
## Feature: Enhanced Content Ingestion with Full Article Fetching and Cleaning

This PR introduces a significant enhancement to the SO Insights application by enabling the fetching, cleaning, and utilization of full article content for improved summarization accuracy, and preparing future work on a better clustering algorithm.

**Motivation:**

The current system relies primarily on article titles and meta-descriptions for clustering and summarization. This approach can lead to suboptimal results, especially in workspaces with limited data volume ("small" workspaces) or when titles and meta-descriptions are poorly written or unrepresentative of the article's content.

**Solution:**

This PR implements the first step of a broader roadmap to address this issue by introducing the capability to fetch and process the full content of articles. The following key changes are included:

1. **Content Fetching Framework:**
    -   Introduced a `UrlToMarkdownConverter` interface to abstract the process of converting a URL to Markdown.
    -   Implemented a `FirecrawlMarkdownConverter` that utilizes the Firecrawl.dev API for robust content extraction.
    
2. **Content Cleaning:**
    -   Implemented an `ArticleContentCleaner` using `gpt-4o-mini` to clean the raw Markdown output from Firecrawl.dev.
    -   Defined a prompt in Langsmith Hub to guide the LLM in removing irrelevant elements (e.g., ads, banners, navigation).

3. **Organization-Level Control:**
    -   Added a `content_analysis_enabled` field to the `Organization` model. This helps manage costs by limiting content fetching to organizations where it's most beneficial.

4. **Integration with Ingestion Pipeline:**
    -   Modified the `ingester` component to conditionally fetch and clean article content based on the organization `content_analysis_enabled` setting.
    -   Updated the `Article` model to store the cleaned Markdown content.

5. **Utilization in Summarization:**
    -   Updated the `ClusterOverviewGenerator` to optionally use the full article content when generating cluster overviews, controlled by the `OVERVIEW_GENERATION_INCLUDE_CONTENTS` setting.

**Future Steps (Out of Scope for this PR):**

-   Implement an article relevance classification system to selectively fetch content for only the most relevant articles.
-   Explore different article chunking strategies and cluster on these chunks instead of full articles.
-   Create an article explorer UI for users to browse and filter collected articles.

**Note:**

This PR depends on the Firecrawl.dev API and requires a valid API key to be configured in the `.env` file.